### PR TITLE
vm: Refactor vm region tree code

### DIFF
--- a/kernel/include/lib/binary_search_tree.h
+++ b/kernel/include/lib/binary_search_tree.h
@@ -251,7 +251,7 @@ struct bst_node *bst_next(const struct bst_root *root, struct bst_node *node);
 #define bst_for_every_entry(root, entry, type, member) \
     for (struct bst_node *_bst_for_every_cursor = bst_next(root, NULL); \
             (_bst_for_every_cursor != NULL) && \
-            ((entry) = containerof(_bst_for_every_cursor, type, member)) && \
+            ((entry) = container_of(_bst_for_every_cursor, type, member)) && \
             ((_bst_for_every_cursor = bst_next(root, _bst_for_every_cursor)) \
              || true);)
 
@@ -274,7 +274,7 @@ void bst_delete_all_helper(struct bst_root *root, struct bst_node *node);
 #define bst_for_every_entry_delete(root, entry, type, member) \
     for (struct bst_node *_bst_for_every_cursor = bst_next(root, NULL); \
             (_bst_for_every_cursor != NULL) && ({\
-            (entry) = containerof(_bst_for_every_cursor, type, member); \
+            (entry) = container_of(_bst_for_every_cursor, type, member); \
             _bst_for_every_cursor = bst_next(root, _bst_for_every_cursor); \
             bst_delete_all_helper(root, &(entry)->member); true;});)
 

--- a/usystem/tests/system_benchmark/src/fork.cpp
+++ b/usystem/tests/system_benchmark/src/fork.cpp
@@ -6,6 +6,7 @@
  * SPDX-License-Identifier: MIT
  */
 
+#include <sys/wait.h>
 #include <unistd.h>
 
 #include <exception>
@@ -15,18 +16,42 @@
 
 static void fork_bench(benchmark::State& state)
 {
-    while (state.KeepRunning())
+    for (auto _ : state)
     {
         pid_t pid = fork();
         if (pid < 0)
         {
-            throw std::runtime_error("Failed to open fd");
+            throw std::runtime_error("Failed to fork");
         }
         else if (pid == 0)
         {
             _exit(0);
         }
     }
+
+    while (waitpid(-1, nullptr, 0) != -1)
+        ;
 }
 
-BENCHMARK(fork_bench);
+BENCHMARK(fork_bench)->ThreadRange(1, 16);
+
+static void vfork_bench(benchmark::State& state)
+{
+    for (auto _ : state)
+    {
+        pid_t pid = vfork();
+        if (pid < 0)
+        {
+            throw std::runtime_error("Failed to fork");
+        }
+        else if (pid == 0)
+        {
+            _exit(0);
+        }
+    }
+
+    while (waitpid(-1, nullptr, 0) != -1)
+        ;
+}
+
+BENCHMARK(vfork_bench)->ThreadRange(1, 16);


### PR DESCRIPTION
Now we use the new WAVL tree rather than the bad RB tree we were using.

Signed-off-by: Pedro Falcato <pedro.falcato@gmail.com>