### PR TITLE
x86: Fix build on CONFIG_ACPI=n

### DIFF
--- a/kernel/arch/x86_64/apic.cpp
+++ b/kernel/arch/x86_64/apic.cpp
@@ -219,7 +219,8 @@ void ioapic_mask_pin(uint32_t pin)
 
 #ifndef CONFIG_ACPI
 
-ACPI_STATUS AcpiGetTable(ACPI_STRING name, UINT32 instance, ACPI_TABLE_HEADER **out)
+acpi_status acpi_get_table(acpi_string signature, u32 instance,
+                           struct acpi_table_header **out_table)
 {
     return AE_NOT_IMPLEMENTED;
 }

--- a/kernel/arch/x86_64/powerctl.cpp
+++ b/kernel/arch/x86_64/powerctl.cpp
@@ -75,7 +75,7 @@ extern "C" int do_machine_reboot(unsigned int flags)
 
 #ifndef CONFIG_ACPI
 
-ACPI_STATUS acpi_shutdown()
+acpi_status acpi_shutdown()
 {
     return AE_NOT_IMPLEMENTED;
 }


### PR DESCRIPTION
Old code was still using old ACPI_ types.

Fixes #62.