### PR TITLE
mmiomap: Make mmiomap use vmalloc internals

### DIFF
--- a/kernel/arch/x86_64/hpet.cpp
+++ b/kernel/arch/x86_64/hpet.cpp
@@ -105,7 +105,7 @@ public:
         if (range != nullptr)
         {
             // Was mapped, unmap it
-            vm_munmap(&kernel_address_space, (void *) range, HPET_EVENT_BLOCK_LENGTH);
+            mmiounmap((void *) range, HPET_EVENT_BLOCK_LENGTH);
         }
     }
 

--- a/kernel/drivers/ata/ata.cpp
+++ b/kernel/drivers/ata/ata.cpp
@@ -159,7 +159,7 @@ public:
 
     ~ide_dev()
     {
-        vm_munmap(&kernel_address_space, prdt, prdt_nr_pages << PAGE_SHIFT);
+        mmiounmap(prdt, prdt_nr_pages << PAGE_SHIFT);
         free_pages(prdt_page);
     }
 

--- a/kernel/drivers/pci/pcie.cpp
+++ b/kernel/drivers/pci/pcie.cpp
@@ -298,7 +298,7 @@ int pcie_init(void)
 
         if (!allocations.push_back(cul::move(allocation)))
         {
-            vm_munmap(&kernel_address_space, (void *) allocation.address, size);
+            mmiounmap((void *) allocation.address, size);
             return -ENOMEM;
         }
 

--- a/kernel/include/onyx/vm.h
+++ b/kernel/include/onyx/vm.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 - 2022 Pedro Falcato
+ * Copyright (c) 2016 - 2023 Pedro Falcato
  * This file is part of Onyx, and is released under the terms of the MIT License
  * check LICENSE at the root directory for more information
  *
@@ -389,6 +389,14 @@ void vm_do_fatal_page_fault(struct fault_info *info);
  * @return A pointer to the new mapping, or NULL with errno set on error.
  */
 void *mmiomap(void *phys, size_t size, size_t flags);
+
+/**
+ * @brief Unmaps a mmio region
+ *
+ * @param virt Virtual address
+ * @param size Size
+ */
+void mmiounmap(void *virt, size_t size);
 
 /**
  * @brief Destroys an address space.

--- a/kernel/kernel/mm/vm.cpp
+++ b/kernel/kernel/mm/vm.cpp
@@ -1888,48 +1888,6 @@ void *map_pages_to_vaddr(void *virt, void *phys, size_t size, size_t flags)
     return __map_pages_to_vaddr(nullptr, virt, phys, size, flags);
 }
 
-/**
- * @brief Creates a mapping of MMIO memory.
- * Note: This function does not add any implicit caching behaviour by default.
- *
- * @param phys The start of the physical range.
- * @param size The size of the physical range.
- * @param flags Permissions on the new region.
- * @return A pointer to the new mapping, or NULL with errno set on error.
- */
-void *mmiomap(void *phys, size_t size, size_t flags)
-{
-    uintptr_t u = (uintptr_t) phys;
-    uintptr_t p_off = u & (PAGE_SIZE - 1);
-
-    size_t pages = vm_size_to_pages(size);
-    if (p_off)
-    {
-        pages++;
-        size += p_off;
-    }
-
-    struct vm_region *entry = vm_allocate_virt_region(flags & VM_USER ? VM_ADDRESS_USER : VM_KERNEL,
-                                                      pages, VM_TYPE_REGULAR, flags);
-    if (!entry)
-    {
-        printf("mmiomap: Could not allocate virtual range\n");
-        return nullptr;
-    }
-
-    u &= ~(PAGE_SIZE - 1);
-
-    /* TODO: Clean up if something goes wrong */
-    void *p = map_pages_to_vaddr((void *) entry->base, (void *) u, size, flags | VM_NOFLUSH);
-    if (!p)
-    {
-        printf("map_pages_to_vaddr: Could not map pages\n");
-        return nullptr;
-    }
-
-    return (void *) ((uintptr_t) p + p_off);
-}
-
 struct vm_pf_context
 {
     /* The vm region in question */


### PR DESCRIPTION
This makes it so we don't need a sleepable lock for mmiomap. Also add mmiounmap to unmap it with.