### PR TITLE
buildpkg: unset CONFIG_SITE while building packages

### DIFF
--- a/scripts/setup_package_build_env.sh
+++ b/scripts/setup_package_build_env.sh
@@ -39,3 +39,4 @@ fi
 
 export PKG_CONFIG=$SYSROOT/../buildpkg/onyx-pkg-config
 export PKG_CONFIG_FOR_BUILD=pkg-config
+unset CONFIG_SITE


### PR DESCRIPTION
This avoids build issues on certain distros which have this variable set