### PR TITLE
[RFC?] Relicense the kernel to GPLv2

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,30 @@
-Copyright (c) 2017 - 2023 Pedro Falcato
+Onyx is licensed under a couple of licenses:
+ - GPLv2 for the kernel (together with MIT code, both first party and third party)
+ - MIT or GPLv2 for anything else
+
+GPLv2 is *generally* (and strongly preferred to be) GPLv2-**ONLY**.
+
+See licenses/ for the relevant, full license texts.
+
+GPLv2:
+Copyright (C) 2024 Pedro Falcato
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+
+MIT:
+Copyright (c) 2017 - 2024 Pedro Falcato
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal
@@ -17,5 +43,3 @@ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
-
-The kernel's rcupdate.cpp and rcupdate.h are licensed under the LGPL-2.0-only license.

--- a/kernel/arch/arm64/copy_user.S
+++ b/kernel/arch/arm64/copy_user.S
@@ -1,6 +1,6 @@
 /*
 * Copyright (c) 2022 Pedro Falcato
-* This file is part of Onyx, and is released under the terms of the MIT License
+* This file is part of Onyx, and is released under the terms of the GPLv2 License
 * check LICENSE at the root directory for more information
 */
 

--- a/kernel/arch/arm64/early_mmu.c
+++ b/kernel/arch/arm64/early_mmu.c
@@ -1,9 +1,9 @@
 /*
  * Copyright (c) 2022 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  *
- * SPDX-License-Identifier: MIT
+ * SPDX-License-Identifier: GPL-2.0-only
  */
 
 #include <stdint.h>

--- a/kernel/arch/arm64/entry.cpp
+++ b/kernel/arch/arm64/entry.cpp
@@ -1,9 +1,9 @@
 /*
  * Copyright (c) 2022 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  *
- * SPDX-License-Identifier: MIT
+ * SPDX-License-Identifier: GPL-2.0-only
  */
 
 #include <libfdt.h>

--- a/kernel/arch/arm64/fpu.cpp
+++ b/kernel/arch/arm64/fpu.cpp
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2022 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  */
 

--- a/kernel/arch/arm64/image.S
+++ b/kernel/arch/arm64/image.S
@@ -1,9 +1,9 @@
 /*
  * Copyright (c) 2022 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  *
- * SPDX-License-Identifier: MIT
+ * SPDX-License-Identifier: GPL-2.0-only
  */
 .section .text
 .global __cxa_atexit

--- a/kernel/arch/arm64/interrupts.S
+++ b/kernel/arch/arm64/interrupts.S
@@ -1,9 +1,9 @@
 /*
  * Copyright (c) 2022 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  *
- * SPDX-License-Identifier: MIT
+ * SPDX-License-Identifier: GPL-2.0-only
  */
 
 .section .text

--- a/kernel/arch/arm64/mmu.cpp
+++ b/kernel/arch/arm64/mmu.cpp
@@ -1,9 +1,9 @@
 /*
  * Copyright (c) 2022 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  *
- * SPDX-License-Identifier: MIT
+ * SPDX-License-Identifier: GPL-2.0-only
  */
 #include <assert.h>
 #include <stdbool.h>

--- a/kernel/arch/arm64/stubs.cpp
+++ b/kernel/arch/arm64/stubs.cpp
@@ -1,10 +1,10 @@
 
 /*
  * Copyright (c) 2022 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  *
- * SPDX-License-Identifier: MIT
+ * SPDX-License-Identifier: GPL-2.0-only
  */
 
 #include <onyx/ktrace.h>

--- a/kernel/arch/arm64/traps.cpp
+++ b/kernel/arch/arm64/traps.cpp
@@ -1,9 +1,9 @@
 /*
  * Copyright (c) 2022 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  *
- * SPDX-License-Identifier: MIT
+ * SPDX-License-Identifier: GPL-2.0-only
  */
 
 #include <onyx/intrinsics.h>

--- a/kernel/arch/arm64/vdso_helper.S
+++ b/kernel/arch/arm64/vdso_helper.S
@@ -1,9 +1,9 @@
 /*
  * Copyright (c) 2022 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  *
- * SPDX-License-Identifier: MIT
+ * SPDX-License-Identifier: GPL-2.0-only
  */
 .section .vdso, "aw"
 

--- a/kernel/arch/arm64/virt-uart.cpp
+++ b/kernel/arch/arm64/virt-uart.cpp
@@ -1,9 +1,9 @@
 /*
  * Copyright (c) 2022 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  *
- * SPDX-License-Identifier: MIT
+ * SPDX-License-Identifier: GPL-2.0-only
  */
 
 // The virt machine's UART is a PL011

--- a/kernel/arch/riscv64/__vdso.c
+++ b/kernel/arch/riscv64/__vdso.c
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2021 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  */
 

--- a/kernel/arch/riscv64/code_patch.cpp
+++ b/kernel/arch/riscv64/code_patch.cpp
@@ -1,9 +1,9 @@
 /*
  * Copyright (c) 2023 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  *
- * SPDX-License-Identifier: MIT
+ * SPDX-License-Identifier: GPL-2.0-only
  */
 #include <onyx/assert.h>
 #include <onyx/code_patch.h>

--- a/kernel/arch/riscv64/copy_user.S
+++ b/kernel/arch/riscv64/copy_user.S
@@ -1,9 +1,9 @@
 /*
  * Copyright (c) 2022 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  *
- * SPDX-License-Identifier: MIT
+ * SPDX-License-Identifier: GPL-2.0-only
  */
 
 # ssize_t copy_to_user_internal(void *user, const void *data, size_t size);

--- a/kernel/arch/riscv64/cpu.cpp
+++ b/kernel/arch/riscv64/cpu.cpp
@@ -1,9 +1,9 @@
 /*
  * Copyright (c) 2022 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  *
- * SPDX-License-Identifier: MIT
+ * SPDX-License-Identifier: GPL-2.0-only
  */
 
 #include <ctype.h>

--- a/kernel/arch/riscv64/debug.cpp
+++ b/kernel/arch/riscv64/debug.cpp
@@ -1,9 +1,9 @@
 /*
  * Copyright (c) 2022 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  *
- * SPDX-License-Identifier: MIT
+ * SPDX-License-Identifier: GPL-2.0-only
  */
 
 #define DEFAULT_UNWIND_NUMBER 6

--- a/kernel/arch/riscv64/early_paging.c
+++ b/kernel/arch/riscv64/early_paging.c
@@ -1,15 +1,15 @@
 /*
  * Copyright (c) 2022 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  *
- * SPDX-License-Identifier: MIT
+ * SPDX-License-Identifier: GPL-2.0-only
  */
 
 #include <stdint.h>
 
-__attribute__((section(".boot"))) __attribute__((no_sanitize("undefined"))) void
-early_paging_setup(uint64_t *boot_page_tables)
+__attribute__((section(".boot"))) __attribute__((no_sanitize("undefined"))) void early_paging_setup(
+    uint64_t *boot_page_tables)
 {
     uint64_t *top_page_table = boot_page_tables;
     uint64_t *second_level[2] = {&boot_page_tables[512], &boot_page_tables[1024]};

--- a/kernel/arch/riscv64/entry.cpp
+++ b/kernel/arch/riscv64/entry.cpp
@@ -1,9 +1,9 @@
 /*
  * Copyright (c) 2022 - 2023 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  *
- * SPDX-License-Identifier: MIT
+ * SPDX-License-Identifier: GPL-2.0-only
  */
 
 #include <libfdt.h>

--- a/kernel/arch/riscv64/fpu.cpp
+++ b/kernel/arch/riscv64/fpu.cpp
@@ -1,9 +1,9 @@
 /*
  * Copyright (c) 2021 - 2022 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  *
- * SPDX-License-Identifier: MIT
+ * SPDX-License-Identifier: GPL-2.0-only
  */
 
 #include <onyx/fpu.h>

--- a/kernel/arch/riscv64/fpu_state.S
+++ b/kernel/arch/riscv64/fpu_state.S
@@ -1,9 +1,9 @@
 /*
  * Copyright (c) 2022 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  *
- * SPDX-License-Identifier: MIT
+ * SPDX-License-Identifier: GPL-2.0-only
  */
 
 .attribute arch, "rv64imafdc"

--- a/kernel/arch/riscv64/image.S
+++ b/kernel/arch/riscv64/image.S
@@ -1,6 +1,6 @@
 /*
 * Copyright (c) 2020 - 2023 Pedro Falcato
-* This file is part of Onyx, and is released under the terms of the MIT License
+* This file is part of Onyx, and is released under the terms of the GPLv2 License
 * check LICENSE at the root directory for more information
 */
 .section .text

--- a/kernel/arch/riscv64/interrupts.S
+++ b/kernel/arch/riscv64/interrupts.S
@@ -1,9 +1,9 @@
 /*
  * Copyright (c) 2022 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  *
- * SPDX-License-Identifier: MIT
+ * SPDX-License-Identifier: GPL-2.0-only
  */
 
 #include <onyx/internal_abi.h>

--- a/kernel/arch/riscv64/mmu.cpp
+++ b/kernel/arch/riscv64/mmu.cpp
@@ -1,9 +1,9 @@
 /*
  * Copyright (c) 2022 - 2024 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  *
- * SPDX-License-Identifier: MIT
+ * SPDX-License-Identifier: GPL-2.0-only
  */
 #include <assert.h>
 #include <stdbool.h>

--- a/kernel/arch/riscv64/plic.cpp
+++ b/kernel/arch/riscv64/plic.cpp
@@ -1,9 +1,9 @@
 /*
  * Copyright (c) 2022 - 2023 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  *
- * SPDX-License-Identifier: MIT
+ * SPDX-License-Identifier: GPL-2.0-only
  */
 
 #include <onyx/device_tree.h>

--- a/kernel/arch/riscv64/power.cpp
+++ b/kernel/arch/riscv64/power.cpp
@@ -1,9 +1,9 @@
 /*
  * Copyright (c) 2022 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  *
- * SPDX-License-Identifier: MIT
+ * SPDX-License-Identifier: GPL-2.0-only
  */
 
 #include <errno.h>

--- a/kernel/arch/riscv64/process.cpp
+++ b/kernel/arch/riscv64/process.cpp
@@ -1,9 +1,9 @@
 /*
  * Copyright (c) 2022 - 2023 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  *
- * SPDX-License-Identifier: MIT
+ * SPDX-License-Identifier: GPL-2.0-only
  */
 
 #include <string.h>

--- a/kernel/arch/riscv64/sbi.cpp
+++ b/kernel/arch/riscv64/sbi.cpp
@@ -1,14 +1,14 @@
 /*
  * Copyright (c) 2022 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  *
- * SPDX-License-Identifier: MIT
+ * SPDX-License-Identifier: GPL-2.0-only
  */
 
 #include <onyx/riscv/sbi.h>
 
-// Stolen from lk, lk/sbi.c
+// Taken from lk, lk/sbi.c
 /*
  * Copyright (c) 2015 Travis Geiselbrecht
  *

--- a/kernel/arch/riscv64/scheduler.cpp
+++ b/kernel/arch/riscv64/scheduler.cpp
@@ -1,9 +1,9 @@
 /*
  * Copyright (c) 2022 - 2023 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  *
- * SPDX-License-Identifier: MIT
+ * SPDX-License-Identifier: GPL-2.0-only
  */
 
 #include <onyx/internal_abi.h>

--- a/kernel/arch/riscv64/signal.cpp
+++ b/kernel/arch/riscv64/signal.cpp
@@ -1,12 +1,11 @@
 /*
  * Copyright (c) 2023 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  *
- * SPDX-License-Identifier: MIT
+ * SPDX-License-Identifier: GPL-2.0-only
  */
 #include <errno.h>
-#include <uapi/signal.h>
 
 #include <onyx/riscv/signal.h>
 #include <onyx/signal.h>

--- a/kernel/arch/riscv64/smp.cpp
+++ b/kernel/arch/riscv64/smp.cpp
@@ -1,9 +1,9 @@
 /*
  * Copyright (c) 2023 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  *
- * SPDX-License-Identifier: MIT
+ * SPDX-License-Identifier: GPL-2.0-only
  */
 
 #include <string.h>

--- a/kernel/arch/riscv64/stubs.cpp
+++ b/kernel/arch/riscv64/stubs.cpp
@@ -1,9 +1,9 @@
 /*
  * Copyright (c) 2022 - 2023 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  *
- * SPDX-License-Identifier: MIT
+ * SPDX-License-Identifier: GPL-2.0-only
  */
 
 #include <onyx/irq.h>

--- a/kernel/arch/riscv64/syscall.cpp
+++ b/kernel/arch/riscv64/syscall.cpp
@@ -1,9 +1,9 @@
 /*
  * Copyright (c) 2022 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  *
- * SPDX-License-Identifier: MIT
+ * SPDX-License-Identifier: GPL-2.0-only
  */
 
 #include <errno.h>

--- a/kernel/arch/riscv64/time.cpp
+++ b/kernel/arch/riscv64/time.cpp
@@ -1,9 +1,9 @@
 /*
  * Copyright (c) 2022 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  *
- * SPDX-License-Identifier: MIT
+ * SPDX-License-Identifier: GPL-2.0-only
  */
 #include <onyx/device_tree.h>
 #include <onyx/riscv/intrinsics.h>

--- a/kernel/arch/riscv64/traps.cpp
+++ b/kernel/arch/riscv64/traps.cpp
@@ -1,9 +1,9 @@
 /*
  * Copyright (c) 2022 - 2023 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  *
- * SPDX-License-Identifier: MIT
+ * SPDX-License-Identifier: GPL-2.0-only
  */
 
 #include <onyx/exceptions.h>

--- a/kernel/arch/riscv64/usercopy.cpp
+++ b/kernel/arch/riscv64/usercopy.cpp
@@ -1,19 +1,20 @@
 /*
  * Copyright (c) 2022 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  *
- * SPDX-License-Identifier: MIT
+ * SPDX-License-Identifier: GPL-2.0-only
  */
 
 #include <errno.h>
-#include <onyx/types.h>
 
 #include <onyx/scheduler.h>
+#include <onyx/types.h>
 #include <onyx/user.h>
 #include <onyx/vm.h>
 
-extern "C" {
+extern "C"
+{
 ssize_t copy_to_user_internal(void *user, const void *data, size_t size);
 ssize_t copy_from_user_internal(void *data, const void *usr, size_t size);
 ssize_t user_memset_internal(void *data, int val, size_t len);

--- a/kernel/arch/riscv64/vdso_helper.S
+++ b/kernel/arch/riscv64/vdso_helper.S
@@ -1,9 +1,9 @@
 /*
  * Copyright (c) 2021 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  *
- * SPDX-License-Identifier: MIT
+ * SPDX-License-Identifier: GPL-2.0-only
  */
 .section .vdso, "aw"
 

--- a/kernel/arch/riscv64/virt-uart.cpp
+++ b/kernel/arch/riscv64/virt-uart.cpp
@@ -1,9 +1,9 @@
 /*
  * Copyright (c) 2022 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  *
- * SPDX-License-Identifier: MIT
+ * SPDX-License-Identifier: GPL-2.0-only
  */
 
 // Very temporary thing, since the virt machine's UART is a 16650

--- a/kernel/arch/x86_64/__vdso.c
+++ b/kernel/arch/x86_64/__vdso.c
@@ -1,9 +1,9 @@
 /*
  * Copyright (c) 2017 - 2021 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  *
- * SPDX-License-Identifier: MIT
+ * SPDX-License-Identifier: GPL-2.0-only
  */
 /* Define the kernel def so we get the extra defs */
 #define __is_onyx_kernel

--- a/kernel/arch/x86_64/__vdso_asm.S
+++ b/kernel/arch/x86_64/__vdso_asm.S
@@ -1,9 +1,9 @@
 /*
  * Copyright (c) 2018 - 2021 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  *
- * SPDX-License-Identifier: MIT
+ * SPDX-License-Identifier: GPL-2.0-only
  */
 
 .global __vdso_syscall

--- a/kernel/arch/x86_64/acpi/acpi.cpp
+++ b/kernel/arch/x86_64/acpi/acpi.cpp
@@ -1,9 +1,9 @@
 /*
  * Copyright (c) 2018 - 2022 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  *
- * SPDX-License-Identifier: MIT
+ * SPDX-License-Identifier: GPL-2.0-only
  */
 
 #include <onyx/acpi.h>

--- a/kernel/arch/x86_64/alternatives.cpp
+++ b/kernel/arch/x86_64/alternatives.cpp
@@ -1,9 +1,9 @@
 /*
  * Copyright (c) 2021 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  *
- * SPDX-License-Identifier: MIT
+ * SPDX-License-Identifier: GPL-2.0-only
  */
 #include <onyx/x86/alternatives.h>
 

--- a/kernel/arch/x86_64/apic.cpp
+++ b/kernel/arch/x86_64/apic.cpp
@@ -1,9 +1,9 @@
 /*
  * Copyright (c) 2016 - 2023 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  *
- * SPDX-License-Identifier: MIT
+ * SPDX-License-Identifier: GPL-2.0-only
  */
 
 #include <assert.h>

--- a/kernel/arch/x86_64/avx.cpp
+++ b/kernel/arch/x86_64/avx.cpp
@@ -1,9 +1,9 @@
 /*
  * Copyright (c) 2017 - 2023 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  *
- * SPDX-License-Identifier: MIT
+ * SPDX-License-Identifier: GPL-2.0-only
  */
 #include <cpuid.h>
 #include <stdint.h>

--- a/kernel/arch/x86_64/boot.S
+++ b/kernel/arch/x86_64/boot.S
@@ -1,9 +1,9 @@
 /*
  * Copyright (c) 2016 - 2023 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  *
- * SPDX-License-Identifier: MIT
+ * SPDX-License-Identifier: GPL-2.0-only
  */
 
 #include <onyx/x86/asm.h>

--- a/kernel/arch/x86_64/code_patch.cpp
+++ b/kernel/arch/x86_64/code_patch.cpp
@@ -1,9 +1,9 @@
 /*
  * Copyright (c) 2023 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  *
- * SPDX-License-Identifier: MIT
+ * SPDX-License-Identifier: GPL-2.0-only
  */
 #include <onyx/code_patch.h>
 #include <onyx/cpu.h>

--- a/kernel/arch/x86_64/copy.S
+++ b/kernel/arch/x86_64/copy.S
@@ -1,9 +1,9 @@
 /*
  * Copyright (c) 2018 - 2023 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  *
- * SPDX-License-Identifier: MIT
+ * SPDX-License-Identifier: GPL-2.0-only
  */
 .section .text
 

--- a/kernel/arch/x86_64/copy_user.S
+++ b/kernel/arch/x86_64/copy_user.S
@@ -1,9 +1,9 @@
 /*
  * Copyright (c) 2019 - 2022 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  *
- * SPDX-License-Identifier: MIT
+ * SPDX-License-Identifier: GPL-2.0-only
  */
 
 #include <onyx/x86/alternatives.h>

--- a/kernel/arch/x86_64/cpu.cpp
+++ b/kernel/arch/x86_64/cpu.cpp
@@ -1,9 +1,9 @@
 /*
  * Copyright (c) 2016 - 2023 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  *
- * SPDX-License-Identifier: MIT
+ * SPDX-License-Identifier: GPL-2.0-only
  */
 
 #include <assert.h>

--- a/kernel/arch/x86_64/debug.cpp
+++ b/kernel/arch/x86_64/debug.cpp
@@ -1,9 +1,9 @@
 /*
  * Copyright (c) 2016 - 2021 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  *
- * SPDX-License-Identifier: MIT
+ * SPDX-License-Identifier: GPL-2.0-only
  */
 
 #include <onyx/cpu.h>

--- a/kernel/arch/x86_64/desc_load.S
+++ b/kernel/arch/x86_64/desc_load.S
@@ -1,9 +1,9 @@
 /*
  * Copyright (c) 2016 - 2022 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  *
- * SPDX-License-Identifier: MIT
+ * SPDX-License-Identifier: GPL-2.0-only
  */
 #include <onyx/x86/asm.h>
 

--- a/kernel/arch/x86_64/disassembler.cpp
+++ b/kernel/arch/x86_64/disassembler.cpp
@@ -1,9 +1,9 @@
 /*
  * Copyright (c) 2018 - 2021 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  *
- * SPDX-License-Identifier: MIT
+ * SPDX-License-Identifier: GPL-2.0-only
  */
 
 #include <stdint.h>

--- a/kernel/arch/x86_64/efi.cpp
+++ b/kernel/arch/x86_64/efi.cpp
@@ -1,9 +1,9 @@
 /*
  * Copyright (c) 2018 - 2023 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  *
- * SPDX-License-Identifier: MIT
+ * SPDX-License-Identifier: GPL-2.0-only
  */
 
 #include <onyx/acpi.h>

--- a/kernel/arch/x86_64/efistub/early.cpp
+++ b/kernel/arch/x86_64/efistub/early.cpp
@@ -1,9 +1,9 @@
 /*
  * Copyright (c) 2023 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  *
- * SPDX-License-Identifier: MIT
+ * SPDX-License-Identifier: GPL-2.0-only
  */
 #include <cpuid.h>
 

--- a/kernel/arch/x86_64/entry.S
+++ b/kernel/arch/x86_64/entry.S
@@ -1,9 +1,9 @@
 /*
  * Copyright (c) 2018 - 2022 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  *
- * SPDX-License-Identifier: MIT
+ * SPDX-License-Identifier: GPL-2.0-only
  */
 
 #include <platform/syscall.h>

--- a/kernel/arch/x86_64/exit.S
+++ b/kernel/arch/x86_64/exit.S
@@ -1,9 +1,9 @@
 /*
  * Copyright (c) 2016 - 2022 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  *
- * SPDX-License-Identifier: MIT
+ * SPDX-License-Identifier: GPL-2.0-only
  */
 
 #include <onyx/registers.h>

--- a/kernel/arch/x86_64/fentry.S
+++ b/kernel/arch/x86_64/fentry.S
@@ -1,9 +1,9 @@
 /*
  * Copyright (c) 2020 - 2022 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  *
- * SPDX-License-Identifier: MIT
+ * SPDX-License-Identifier: GPL-2.0-only
  */
 
 #include <onyx/x86/segments.h>

--- a/kernel/arch/x86_64/fpu.cpp
+++ b/kernel/arch/x86_64/fpu.cpp
@@ -1,9 +1,9 @@
 /*
  * Copyright (c) 2016 - 2023 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  *
- * SPDX-License-Identifier: MIT
+ * SPDX-License-Identifier: GPL-2.0-only
  */
 #include <stdint.h>
 #include <stdio.h>

--- a/kernel/arch/x86_64/gdt.cpp
+++ b/kernel/arch/x86_64/gdt.cpp
@@ -1,9 +1,9 @@
 /*
  * Copyright (c) 2017 - 2021 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  *
- * SPDX-License-Identifier: MIT
+ * SPDX-License-Identifier: GPL-2.0-only
  */
 #include <stdlib.h>
 #include <string.h>

--- a/kernel/arch/x86_64/hpet.cpp
+++ b/kernel/arch/x86_64/hpet.cpp
@@ -1,9 +1,9 @@
 /*
  * Copyright (c) 2021 - 2022 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  *
- * SPDX-License-Identifier: MIT
+ * SPDX-License-Identifier: GPL-2.0-only
  */
 
 #include <onyx/acpi.h>

--- a/kernel/arch/x86_64/idt.cpp
+++ b/kernel/arch/x86_64/idt.cpp
@@ -1,9 +1,9 @@
 /*
  * Copyright (c) 2016 - 2021 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  *
- * SPDX-License-Identifier: MIT
+ * SPDX-License-Identifier: GPL-2.0-only
  */
 #include <assert.h>
 #include <string.h>

--- a/kernel/arch/x86_64/interrupts.S
+++ b/kernel/arch/x86_64/interrupts.S
@@ -1,9 +1,9 @@
 /*
  * Copyright (c) 2016 - 2022 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  *
- * SPDX-License-Identifier: MIT
+ * SPDX-License-Identifier: GPL-2.0-only
  */
 
 #include <onyx/registers.h>

--- a/kernel/arch/x86_64/irq.cpp
+++ b/kernel/arch/x86_64/irq.cpp
@@ -1,9 +1,9 @@
 /*
  * Copyright (c) 2016 - 2022 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  *
- * SPDX-License-Identifier: MIT
+ * SPDX-License-Identifier: GPL-2.0-only
  */
 
 #include <assert.h>

--- a/kernel/arch/x86_64/isr.cpp
+++ b/kernel/arch/x86_64/isr.cpp
@@ -1,9 +1,9 @@
 /*
  * Copyright (c) 2016 - 2024 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  *
- * SPDX-License-Identifier: MIT
+ * SPDX-License-Identifier: GPL-2.0-only
  */
 #include <stdbool.h>
 #include <stdint.h>

--- a/kernel/arch/x86_64/ktrace.cpp
+++ b/kernel/arch/x86_64/ktrace.cpp
@@ -1,9 +1,9 @@
 /*
  * Copyright (c) 2020 - 2023 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  *
- * SPDX-License-Identifier: MIT
+ * SPDX-License-Identifier: GPL-2.0-only
  */
 
 #include <stdint.h>

--- a/kernel/arch/x86_64/kvm.cpp
+++ b/kernel/arch/x86_64/kvm.cpp
@@ -1,9 +1,9 @@
 /*
  * Copyright (c) 2019 - 2022 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  *
- * SPDX-License-Identifier: MIT
+ * SPDX-License-Identifier: GPL-2.0-only
  */
 #include <cpuid.h>
 #include <stdio.h>

--- a/kernel/arch/x86_64/mce.cpp
+++ b/kernel/arch/x86_64/mce.cpp
@@ -1,9 +1,9 @@
 /*
  * Copyright (c) 2017 - 2021 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  *
- * SPDX-License-Identifier: MIT
+ * SPDX-License-Identifier: GPL-2.0-only
  */
 
 #include <cpuid.h>

--- a/kernel/arch/x86_64/mmu.cpp
+++ b/kernel/arch/x86_64/mmu.cpp
@@ -1,9 +1,9 @@
 /*
  * Copyright (c) 2016 - 2024 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  *
- * SPDX-License-Identifier: MIT
+ * SPDX-License-Identifier: GPL-2.0-only
  */
 #include <assert.h>
 #include <cpuid.h>

--- a/kernel/arch/x86_64/multiboot2.cpp
+++ b/kernel/arch/x86_64/multiboot2.cpp
@@ -1,9 +1,9 @@
 /*
  * Copyright (c) 2018 - 2023 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  *
- * SPDX-License-Identifier: MIT
+ * SPDX-License-Identifier: GPL-2.0-only
  */
 #include <assert.h>
 #include <errno.h>

--- a/kernel/arch/x86_64/pat.cpp
+++ b/kernel/arch/x86_64/pat.cpp
@@ -1,9 +1,9 @@
 /*
  * Copyright (c) 2018 - 2021 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  *
- * SPDX-License-Identifier: MIT
+ * SPDX-License-Identifier: GPL-2.0-only
  */
 
 #include <onyx/cpu.h>

--- a/kernel/arch/x86_64/pic.cpp
+++ b/kernel/arch/x86_64/pic.cpp
@@ -1,9 +1,9 @@
 /*
  * Copyright (c) 2016 - 2021 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  *
- * SPDX-License-Identifier: MIT
+ * SPDX-License-Identifier: GPL-2.0-only
  */
 #include <stdint.h>
 

--- a/kernel/arch/x86_64/pit.cpp
+++ b/kernel/arch/x86_64/pit.cpp
@@ -1,9 +1,9 @@
 /*
  * Copyright (c) 2016 - 2021 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  *
- * SPDX-License-Identifier: MIT
+ * SPDX-License-Identifier: GPL-2.0-only
  */
 
 #include <assert.h>

--- a/kernel/arch/x86_64/powerctl.cpp
+++ b/kernel/arch/x86_64/powerctl.cpp
@@ -1,9 +1,9 @@
 /*
  * Copyright (c) 2020 - 2022 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  *
- * SPDX-License-Identifier: MIT
+ * SPDX-License-Identifier: GPL-2.0-only
  */
 
 #include <errno.h>

--- a/kernel/arch/x86_64/process.cpp
+++ b/kernel/arch/x86_64/process.cpp
@@ -1,9 +1,9 @@
 /*
  * Copyright (c) 2020 - 2021 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  *
- * SPDX-License-Identifier: MIT
+ * SPDX-License-Identifier: GPL-2.0-only
  */
 #include <errno.h>
 

--- a/kernel/arch/x86_64/ptrace.cpp
+++ b/kernel/arch/x86_64/ptrace.cpp
@@ -1,9 +1,9 @@
 /*
  * Copyright (c) 2017 - 2021 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  *
- * SPDX-License-Identifier: MIT
+ * SPDX-License-Identifier: GPL-2.0-only
  */
 #include <errno.h>
 #include <stdbool.h>

--- a/kernel/arch/x86_64/random.cpp
+++ b/kernel/arch/x86_64/random.cpp
@@ -1,9 +1,9 @@
 /*
  * Copyright (c) 2021 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  *
- * SPDX-License-Identifier: MIT
+ * SPDX-License-Identifier: GPL-2.0-only
  */
 
 #include <onyx/cpu.h>

--- a/kernel/arch/x86_64/realmode.S
+++ b/kernel/arch/x86_64/realmode.S
@@ -1,9 +1,9 @@
 /*
  * Copyright (c) 2018 - 2023 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  *
- * SPDX-License-Identifier: MIT
+ * SPDX-License-Identifier: GPL-2.0-only
  */
 #include <onyx/x86/control_regs.h>
 #include <onyx/x86/msr.h>

--- a/kernel/arch/x86_64/rethunk.S
+++ b/kernel/arch/x86_64/rethunk.S
@@ -1,9 +1,9 @@
 /*
  * Copyright (c) 2022 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  *
- * SPDX-License-Identifier: MIT
+ * SPDX-License-Identifier: GPL-2.0-only
  */
 
 #include <onyx/x86/asm.h>

--- a/kernel/arch/x86_64/signal.cpp
+++ b/kernel/arch/x86_64/signal.cpp
@@ -1,12 +1,11 @@
 /*
  * Copyright (c) 2019 - 2021 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  *
- * SPDX-License-Identifier: MIT
+ * SPDX-License-Identifier: GPL-2.0-only
  */
 #include <errno.h>
-#include <uapi/signal.h>
 #include <stdint.h>
 #include <stdio.h>
 
@@ -18,6 +17,8 @@
 #include <onyx/x86/eflags.h>
 #include <onyx/x86/segments.h>
 #include <onyx/x86/signal.h>
+
+#include <uapi/signal.h>
 
 /* The sysv abi defines a 128 byte zone below the stack so we need to be
  * careful as to not touch it

--- a/kernel/arch/x86_64/smbios.cpp
+++ b/kernel/arch/x86_64/smbios.cpp
@@ -1,9 +1,9 @@
 /*
  * Copyright (c) 2016 - 2023 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  *
- * SPDX-License-Identifier: MIT
+ * SPDX-License-Identifier: GPL-2.0-only
  */
 #include <stdio.h>
 #include <string.h>

--- a/kernel/arch/x86_64/smp.cpp
+++ b/kernel/arch/x86_64/smp.cpp
@@ -1,9 +1,9 @@
 /*
  * Copyright (c) 2019 - 2023 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  *
- * SPDX-License-Identifier: MIT
+ * SPDX-License-Identifier: GPL-2.0-only
  */
 #include <onyx/acpi.h>
 #include <onyx/cpu.h>

--- a/kernel/arch/x86_64/strace.cpp
+++ b/kernel/arch/x86_64/strace.cpp
@@ -1,9 +1,9 @@
 /*
  * Copyright (c) 2016 - 2023 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  *
- * SPDX-License-Identifier: MIT
+ * SPDX-License-Identifier: GPL-2.0-only
  */
 #include <math.h>
 #include <multiboot2.h>

--- a/kernel/arch/x86_64/syscall.cpp
+++ b/kernel/arch/x86_64/syscall.cpp
@@ -1,9 +1,9 @@
 /*
  * Copyright (c) 2018 - 2021 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  *
- * SPDX-License-Identifier: MIT
+ * SPDX-License-Identifier: GPL-2.0-only
  */
 
 #include <errno.h>

--- a/kernel/arch/x86_64/thread.cpp
+++ b/kernel/arch/x86_64/thread.cpp
@@ -1,9 +1,9 @@
 /*
  * Copyright (c) 2016 - 2023 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  *
- * SPDX-License-Identifier: MIT
+ * SPDX-License-Identifier: GPL-2.0-only
  */
 #include <errno.h>
 #include <stdbool.h>

--- a/kernel/arch/x86_64/tsc.cpp
+++ b/kernel/arch/x86_64/tsc.cpp
@@ -1,9 +1,9 @@
 /*
  * Copyright (c) 2017 - 2021 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  *
- * SPDX-License-Identifier: MIT
+ * SPDX-License-Identifier: GPL-2.0-only
  */
 
 #include <fractions.h>

--- a/kernel/arch/x86_64/tss.cpp
+++ b/kernel/arch/x86_64/tss.cpp
@@ -1,9 +1,9 @@
 /*
  * Copyright (c) 2016 - 2021 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  *
- * SPDX-License-Identifier: MIT
+ * SPDX-License-Identifier: GPL-2.0-only
  */
 #include <stdio.h>
 #include <string.h>

--- a/kernel/arch/x86_64/vdso_helper.S
+++ b/kernel/arch/x86_64/vdso_helper.S
@@ -1,9 +1,9 @@
 /*
  * Copyright (c) 2018 - 2023 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  *
- * SPDX-License-Identifier: MIT
+ * SPDX-License-Identifier: GPL-2.0-only
  */
 .section .data, "aw"
 

--- a/kernel/arch/x86_64/vm.cpp
+++ b/kernel/arch/x86_64/vm.cpp
@@ -1,9 +1,9 @@
 /*
  * Copyright (c) 2017 - 2023 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  *
- * SPDX-License-Identifier: MIT
+ * SPDX-License-Identifier: GPL-2.0-only
  */
 #include <assert.h>
 #include <cpuid.h>

--- a/kernel/drivers/firmware/efi/efi.cpp
+++ b/kernel/drivers/firmware/efi/efi.cpp
@@ -1,9 +1,9 @@
 /*
  * Copyright (c) 2022 - 2024 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  *
- * SPDX-License-Identifier: MIT
+ * SPDX-License-Identifier: GPL-2.0-only
  */
 #define pr_fmt(fmt) "efi: " fmt
 

--- a/kernel/include/efi/efi.h
+++ b/kernel/include/efi/efi.h
@@ -1,9 +1,9 @@
 /*
  * Copyright (c) 2022 - 2023 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  *
- * SPDX-License-Identifier: MIT
+ * SPDX-License-Identifier: GPL-2.0-only
  */
 #ifndef _ONYX_EFI_EFI_H
 #define _ONYX_EFI_EFI_H

--- a/kernel/include/efi/protocol/initrd.h
+++ b/kernel/include/efi/protocol/initrd.h
@@ -1,9 +1,9 @@
 /*
  * Copyright (c) 2023 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  *
- * SPDX-License-Identifier: MIT
+ * SPDX-License-Identifier: GPL-2.0-only
  */
 #ifndef _ONYX_EFI_PROTOCOL_INITRD_H
 #define _ONYX_EFI_PROTOCOL_INITRD_H

--- a/kernel/include/efi/protocol/loadfile.h
+++ b/kernel/include/efi/protocol/loadfile.h
@@ -1,9 +1,9 @@
 /*
  * Copyright (c) 2023 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  *
- * SPDX-License-Identifier: MIT
+ * SPDX-License-Identifier: GPL-2.0-only
  */
 
 #ifndef _ONYX_EFI_PROTOCOL_LOADFILE_H

--- a/kernel/include/fractions.h
+++ b/kernel/include/fractions.h
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2019 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  */
 

--- a/kernel/include/libtest/libtest.h
+++ b/kernel/include/libtest/libtest.h
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2017 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  */
 

--- a/kernel/include/onyx/acpi.h
+++ b/kernel/include/onyx/acpi.h
@@ -1,9 +1,9 @@
 /*
  * Copyright (c) 2016 - 2022 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  *
- * SPDX-License-Identifier: MIT
+ * SPDX-License-Identifier: GPL-2.0-only
  */
 
 #ifndef _ONYX_ACPI_H

--- a/kernel/include/onyx/anon_inode.h
+++ b/kernel/include/onyx/anon_inode.h
@@ -1,9 +1,9 @@
 /*
  * Copyright (c) 2023 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  *
- * SPDX-License-Identifier: MIT
+ * SPDX-License-Identifier: GPL-2.0-only
  */
 
 #ifndef _ONYX_ANON_INODE_H

--- a/kernel/include/onyx/arch.h
+++ b/kernel/include/onyx/arch.h
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2019 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  */
 #ifndef _ONYX_ARCH_H

--- a/kernel/include/onyx/arm64/include/platform/atomic.h
+++ b/kernel/include/onyx/arm64/include/platform/atomic.h
@@ -1,9 +1,9 @@
 /*
  * Copyright (c) 2024 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  *
- * SPDX-License-Identifier: MIT
+ * SPDX-License-Identifier: GPL-2.0-only
  */
 
 #define smp_rmb() __asm__ __volatile__("dmb ishld" ::: "memory")

--- a/kernel/include/onyx/arm64/include/platform/elf.h
+++ b/kernel/include/onyx/arm64/include/platform/elf.h
@@ -1,9 +1,9 @@
 /*
  * Copyright (c) 2022 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  *
- * SPDX-License-Identifier: MIT
+ * SPDX-License-Identifier: GPL-2.0-only
  */
 #ifndef ONYX_ARM64_INCLUDE_PLATFORM_ELF_H
 #define ONYX_ARM64_INCLUDE_PLATFORM_ELF_H

--- a/kernel/include/onyx/arm64/include/platform/internal_abi.h
+++ b/kernel/include/onyx/arm64/include/platform/internal_abi.h
@@ -1,9 +1,9 @@
 /*
  * Copyright (c) 2022 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  *
- * SPDX-License-Identifier: MIT
+ * SPDX-License-Identifier: GPL-2.0-only
  */
 #ifndef _ONYX_ARM64_PLATFORM_INTERNAL_ABI_H
 #define _ONYX_ARM64_PLATFORM_INTERNAL_ABI_H

--- a/kernel/include/onyx/arm64/include/platform/irq.h
+++ b/kernel/include/onyx/arm64/include/platform/irq.h
@@ -1,9 +1,9 @@
 /*
  * Copyright (c) 2022 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  *
- * SPDX-License-Identifier: MIT
+ * SPDX-License-Identifier: GPL-2.0-only
  */
 
 #ifndef _ONYX_ARM64_PLATFORM_IRQ_H

--- a/kernel/include/onyx/arm64/include/platform/page.h
+++ b/kernel/include/onyx/arm64/include/platform/page.h
@@ -1,9 +1,9 @@
 /*
  * Copyright (c) 2022 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  *
- * SPDX-License-Identifier: MIT
+ * SPDX-License-Identifier: GPL-2.0-only
  */
 
 #ifndef _ONYX_ARM64_PAGE_H

--- a/kernel/include/onyx/arm64/include/platform/syscall.h
+++ b/kernel/include/onyx/arm64/include/platform/syscall.h
@@ -1,9 +1,9 @@
 /*
  * Copyright (c) 2022 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  *
- * SPDX-License-Identifier: MIT
+ * SPDX-License-Identifier: GPL-2.0-only
  */
 
 #ifndef _ONYX_ARM64_PLATFORM_SYSCALL_H

--- a/kernel/include/onyx/arm64/include/platform/vm.h
+++ b/kernel/include/onyx/arm64/include/platform/vm.h
@@ -1,9 +1,9 @@
 /*
  * Copyright (c) 2022 - 2023 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  *
- * SPDX-License-Identifier: MIT
+ * SPDX-License-Identifier: GPL-2.0-only
  */
 
 #ifndef _ONYX_ARM64_PLATFORM_VM_H

--- a/kernel/include/onyx/arm64/include/platform/vm_layout.h
+++ b/kernel/include/onyx/arm64/include/platform/vm_layout.h
@@ -1,9 +1,9 @@
 /*
  * Copyright (c) 2022 - 2023 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  *
- * SPDX-License-Identifier: MIT
+ * SPDX-License-Identifier: GPL-2.0-only
  */
 
 #ifndef _ONYX_ARM64_PLATFORM_VM_LAYOUT_H

--- a/kernel/include/onyx/arm64/intrinsics.h
+++ b/kernel/include/onyx/arm64/intrinsics.h
@@ -1,9 +1,9 @@
 /*
  * Copyright (c) 2022 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  *
- * SPDX-License-Identifier: MIT
+ * SPDX-License-Identifier: GPL-2.0-only
  */
 
 #ifndef _ONYX_ARM64_INTRINSICS_H

--- a/kernel/include/onyx/arm64/mmu.h
+++ b/kernel/include/onyx/arm64/mmu.h
@@ -1,9 +1,9 @@
 /*
  * Copyright (c) 2022 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  *
- * SPDX-License-Identifier: MIT
+ * SPDX-License-Identifier: GPL-2.0-only
  */
 #ifndef _ONYX_ARM64_MMU_H
 #define _ONYX_ARM64_MMU_H

--- a/kernel/include/onyx/arm64/percpu.h
+++ b/kernel/include/onyx/arm64/percpu.h
@@ -1,9 +1,9 @@
 /*
  * Copyright (c) 2022 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  *
- * SPDX-License-Identifier: MIT
+ * SPDX-License-Identifier: GPL-2.0-only
  */
 
 #ifndef _ONYX_ARM64_PERCPU_H

--- a/kernel/include/onyx/array.h
+++ b/kernel/include/onyx/array.h
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2019 Pedro Falcato
- * This file is part of Carbon, and is released under the terms of the MIT License
+ * This file is part of Carbon, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  */
 

--- a/kernel/include/onyx/array_iterator.h
+++ b/kernel/include/onyx/array_iterator.h
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2019 Pedro Falcato
- * This file is part of Carbon, and is released under the terms of the MIT License
+ * This file is part of Carbon, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  */
 

--- a/kernel/include/onyx/assert.h
+++ b/kernel/include/onyx/assert.h
@@ -1,9 +1,9 @@
 /*
  * Copyright (c) 2022 - 2023 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  *
- * SPDX-License-Identifier: MIT
+ * SPDX-License-Identifier: GPL-2.0-only
  */
 #ifndef _ONYX_ASSERT_H
 #define _ONYX_ASSERT_H

--- a/kernel/include/onyx/async_io.h
+++ b/kernel/include/onyx/async_io.h
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2018 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  */
 #ifndef _ONYX_ASYNC_IO_H

--- a/kernel/include/onyx/atomic.h
+++ b/kernel/include/onyx/atomic.h
@@ -1,9 +1,9 @@
 /*
  * Copyright (c) 2024 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  *
- * SPDX-License-Identifier: MIT
+ * SPDX-License-Identifier: GPL-2.0-only
  */
 #ifndef _ONYX_ATOMIC_H
 #define _ONYX_ATOMIC_H

--- a/kernel/include/onyx/atomic.hpp
+++ b/kernel/include/onyx/atomic.hpp
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2019 Pedro Falcato
- * This file is part of Carbon, and is released under the terms of the MIT License
+ * This file is part of Carbon, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  */
 

--- a/kernel/include/onyx/auto_resource.h
+++ b/kernel/include/onyx/auto_resource.h
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2020 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  */
 

--- a/kernel/include/onyx/bdev_base_types.h
+++ b/kernel/include/onyx/bdev_base_types.h
@@ -1,9 +1,9 @@
 /*
  * Copyright (c) 2016 - 2024 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  *
- * SPDX-License-Identifier: MIT
+ * SPDX-License-Identifier: GPL-2.0-only
  */
 #ifndef _ONYX_BDEV_BASE_TYPES_H
 #define _ONYX_BDEV_BASE_TYPES_H

--- a/kernel/include/onyx/binfmt.h
+++ b/kernel/include/onyx/binfmt.h
@@ -1,9 +1,9 @@
 /*
  * Copyright (c) 2017 - 2021 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  *
- * SPDX-License-Identifier: MIT
+ * SPDX-License-Identifier: GPL-2.0-only
  */
 #ifndef _ONYX_BINFMT_H
 #define _ONYX_BINFMT_H

--- a/kernel/include/onyx/bio.h
+++ b/kernel/include/onyx/bio.h
@@ -1,9 +1,9 @@
 /*
  * Copyright (c) 2016 - 2024 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  *
- * SPDX-License-Identifier: MIT
+ * SPDX-License-Identifier: GPL-2.0-only
  */
 #ifndef _ONYX_BIO_H
 #define _ONYX_BIO_H

--- a/kernel/include/onyx/bitmap.h
+++ b/kernel/include/onyx/bitmap.h
@@ -1,9 +1,9 @@
 /*
  * Copyright (c) 2019 - 2022 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  *
- * SPDX-License-Identifier: MIT
+ * SPDX-License-Identifier: GPL-2.0-only
  */
 #ifndef _ONYX_BITMAP_H
 #define _ONYX_BITMAP_H

--- a/kernel/include/onyx/block.h
+++ b/kernel/include/onyx/block.h
@@ -1,9 +1,9 @@
 /*
  * Copyright (c) 2016 - 2024 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  *
- * SPDX-License-Identifier: MIT
+ * SPDX-License-Identifier: GPL-2.0-only
  */
 #ifndef _ONYX_BLOCK_H
 #define _ONYX_BLOCK_H

--- a/kernel/include/onyx/block/blk_plug.h
+++ b/kernel/include/onyx/block/blk_plug.h
@@ -1,9 +1,9 @@
 /*
  * Copyright (c) 2024 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  *
- * SPDX-License-Identifier: MIT
+ * SPDX-License-Identifier: GPL-2.0-only
  */
 #ifndef _ONYX_BLOCK_BLK_PLUG_H
 #define _ONYX_BLOCK_BLK_PLUG_H

--- a/kernel/include/onyx/block/io-queue.h
+++ b/kernel/include/onyx/block/io-queue.h
@@ -1,9 +1,9 @@
 /*
  * Copyright (c) 2022 - 2024 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  *
- * SPDX-License-Identifier: MIT
+ * SPDX-License-Identifier: GPL-2.0-only
  */
 
 #ifndef _ONYX_BLOCK_IO_QUEUE_H

--- a/kernel/include/onyx/block/multiqueue.h
+++ b/kernel/include/onyx/block/multiqueue.h
@@ -1,9 +1,9 @@
 /*
  * Copyright (c) 2024 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  *
- * SPDX-License-Identifier: MIT
+ * SPDX-License-Identifier: GPL-2.0-only
  */
 
 #ifndef _ONYX_BLOCK_MULTIQUEUE_H

--- a/kernel/include/onyx/block/request.h
+++ b/kernel/include/onyx/block/request.h
@@ -1,9 +1,9 @@
 /*
  * Copyright (c) 2024 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  *
- * SPDX-License-Identifier: MIT
+ * SPDX-License-Identifier: GPL-2.0-only
  */
 #ifndef _ONYX_BLOCK_REQUEST_H
 #define _ONYX_BLOCK_REQUEST_H

--- a/kernel/include/onyx/bootmem.h
+++ b/kernel/include/onyx/bootmem.h
@@ -1,9 +1,9 @@
 /*
  * Copyright (c) 2016 - 2022 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  *
- * SPDX-License-Identifier: MIT
+ * SPDX-License-Identifier: GPL-2.0-only
  */
 
 #ifndef _ONYX_BOOTMEM_H

--- a/kernel/include/onyx/buffer.h
+++ b/kernel/include/onyx/buffer.h
@@ -1,9 +1,9 @@
 /*
  * Copyright (c) 2020 - 2023 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  *
- * SPDX-License-Identifier: MIT
+ * SPDX-License-Identifier: GPL-2.0-only
  */
 #ifndef _ONYX_BUFFER_H
 #define _ONYX_BUFFER_H

--- a/kernel/include/onyx/bus_type.h
+++ b/kernel/include/onyx/bus_type.h
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2021 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  */
 

--- a/kernel/include/onyx/byteswap.h
+++ b/kernel/include/onyx/byteswap.h
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2020 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  */
 #ifndef _ONYX_BYTESWAP_H

--- a/kernel/include/onyx/clock.h
+++ b/kernel/include/onyx/clock.h
@@ -1,9 +1,9 @@
 /*
  * Copyright (c) 2017 - 2022 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  *
- * SPDX-License-Identifier: MIT
+ * SPDX-License-Identifier: GPL-2.0-only
  */
 
 #ifndef _ONYX_CLOCK_H

--- a/kernel/include/onyx/cmdline.h
+++ b/kernel/include/onyx/cmdline.h
@@ -1,9 +1,9 @@
 /*
  * Copyright (c) 2021 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  *
- * SPDX-License-Identifier: MIT
+ * SPDX-License-Identifier: GPL-2.0-only
  */
 
 #ifndef _ONYX_CMDLINE_H

--- a/kernel/include/onyx/code_patch.h
+++ b/kernel/include/onyx/code_patch.h
@@ -1,9 +1,9 @@
 /*
  * Copyright (c) 2023 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  *
- * SPDX-License-Identifier: MIT
+ * SPDX-License-Identifier: GPL-2.0-only
  */
 #ifndef _ONYX_CODE_PATCH_H
 #define _ONYX_CODE_PATCH_H

--- a/kernel/include/onyx/compiler.h
+++ b/kernel/include/onyx/compiler.h
@@ -1,9 +1,9 @@
 /*
  * Copyright (c) 2016 - 2023 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  *
- * SPDX-License-Identifier: MIT
+ * SPDX-License-Identifier: GPL-2.0-only
  */
 
 #ifndef _ONYX_COMPILER_H

--- a/kernel/include/onyx/compression.h
+++ b/kernel/include/onyx/compression.h
@@ -1,9 +1,9 @@
 /*
  * Copyright (c) 2022 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  *
- * SPDX-License-Identifier: MIT
+ * SPDX-License-Identifier: GPL-2.0-only
  */
 #ifndef _ONYX_COMPRESSION_H
 #define _ONYX_COMPRESSION_H

--- a/kernel/include/onyx/conditional.h
+++ b/kernel/include/onyx/conditional.h
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2019 Pedro Falcato
- * This file is part of Carbon, and is released under the terms of the MIT License
+ * This file is part of Carbon, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  */
 

--- a/kernel/include/onyx/condvar.h
+++ b/kernel/include/onyx/condvar.h
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2018 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  */
 #ifndef _ONYX_CONDVAR_H

--- a/kernel/include/onyx/console.h
+++ b/kernel/include/onyx/console.h
@@ -1,9 +1,9 @@
 /*
  * Copyright (c) 2024 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  *
- * SPDX-License-Identifier: MIT
+ * SPDX-License-Identifier: GPL-2.0-only
  */
 #ifndef _ONYX_CONSOLE_H
 #define _ONYX_CONSOLE_H

--- a/kernel/include/onyx/copy.h
+++ b/kernel/include/onyx/copy.h
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2018 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  */
 

--- a/kernel/include/onyx/cpu.h
+++ b/kernel/include/onyx/cpu.h
@@ -1,9 +1,9 @@
 /*
  * Copyright (c) 2016 - 2022 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  *
- * SPDX-License-Identifier: MIT
+ * SPDX-License-Identifier: GPL-2.0-only
  */
 
 #ifndef _ONYX_CPU_H

--- a/kernel/include/onyx/cpumask.h
+++ b/kernel/include/onyx/cpumask.h
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2020 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  */
 #ifndef _ONYX_CPUMASK_H

--- a/kernel/include/onyx/cputime.h
+++ b/kernel/include/onyx/cputime.h
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2020 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  */
 

--- a/kernel/include/onyx/crc32.h
+++ b/kernel/include/onyx/crc32.h
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2016, 2017 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  */
 #ifndef _KERNEL_CRC32_H

--- a/kernel/include/onyx/cred.h
+++ b/kernel/include/onyx/cred.h
@@ -1,9 +1,9 @@
 /*
  * Copyright (c) 2020 - 2022 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  *
- * SPDX-License-Identifier: MIT
+ * SPDX-License-Identifier: GPL-2.0-only
  */
 #ifndef _ONYX_CRED_H
 #define _ONYX_CRED_H

--- a/kernel/include/onyx/crypt/sha256.h
+++ b/kernel/include/onyx/crypt/sha256.h
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2017 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  */
 

--- a/kernel/include/onyx/culstring.h
+++ b/kernel/include/onyx/culstring.h
@@ -1,9 +1,9 @@
 /*
  * Copyright (c) 2021 - 2023 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  *
- * SPDX-License-Identifier: MIT
+ * SPDX-License-Identifier: GPL-2.0-only
  */
 #ifndef _ONYX_STRING_H
 #define _ONYX_STRING_H

--- a/kernel/include/onyx/date.h
+++ b/kernel/include/onyx/date.h
@@ -1,9 +1,9 @@
 /*
  * Copyright (c) 2016 - 2024 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  *
- * SPDX-License-Identifier: MIT
+ * SPDX-License-Identifier: GPL-2.0-only
  */
 #ifndef _ONYX_DATE_H
 #define _ONYX_DATE_H

--- a/kernel/include/onyx/debug.h
+++ b/kernel/include/onyx/debug.h
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2017 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  */
 

--- a/kernel/include/onyx/deleter.hpp
+++ b/kernel/include/onyx/deleter.hpp
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2019 Pedro Falcato
- * This file is part of Carbon, and is released under the terms of the MIT License
+ * This file is part of Carbon, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  */
 

--- a/kernel/include/onyx/dentry.h
+++ b/kernel/include/onyx/dentry.h
@@ -1,9 +1,9 @@
 /*
  * Copyright (c) 2018 - 2023 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  *
- * SPDX-License-Identifier: MIT
+ * SPDX-License-Identifier: GPL-2.0-only
  */
 
 #ifndef _ONYX_DENTRY_H

--- a/kernel/include/onyx/dev.h
+++ b/kernel/include/onyx/dev.h
@@ -1,9 +1,9 @@
 /*
  * Copyright (c) 2016 - 2024 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  *
- * SPDX-License-Identifier: MIT
+ * SPDX-License-Identifier: GPL-2.0-only
  */
 
 #ifndef _ONYX_DEV_H

--- a/kernel/include/onyx/dev_resource.h
+++ b/kernel/include/onyx/dev_resource.h
@@ -1,9 +1,9 @@
 /*
  * Copyright (c) 2021 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  *
- * SPDX-License-Identifier: MIT
+ * SPDX-License-Identifier: GPL-2.0-only
  */
 #ifndef _ONYX_DEV_RESOURCE_H
 #define _ONYX_DEV_RESOURCE_H

--- a/kernel/include/onyx/device_tree.h
+++ b/kernel/include/onyx/device_tree.h
@@ -1,9 +1,9 @@
 /*
  * Copyright (c) 2022 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  *
- * SPDX-License-Identifier: MIT
+ * SPDX-License-Identifier: GPL-2.0-only
  */
 #ifndef _ONYX_DEVICE_TREE_H
 #define _ONYX_DEVICE_TREE_H

--- a/kernel/include/onyx/disassembler.h
+++ b/kernel/include/onyx/disassembler.h
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2018 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  */
 

--- a/kernel/include/onyx/dma.h
+++ b/kernel/include/onyx/dma.h
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2018 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  */
 

--- a/kernel/include/onyx/dpc.h
+++ b/kernel/include/onyx/dpc.h
@@ -1,9 +1,9 @@
 /*
  * Copyright (c) 2017 - 2022 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  *
- * SPDX-License-Identifier: MIT
+ * SPDX-License-Identifier: GPL-2.0-only
  */
 
 #ifndef _ONYX_DPC_H

--- a/kernel/include/onyx/driver.h
+++ b/kernel/include/onyx/driver.h
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2017 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  */
 #ifndef _KERNEL_DRIVER_H

--- a/kernel/include/onyx/enable_if.h
+++ b/kernel/include/onyx/enable_if.h
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2019 Pedro Falcato
- * This file is part of Carbon, and is released under the terms of the MIT License
+ * This file is part of Carbon, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  */
 

--- a/kernel/include/onyx/exceptions.h
+++ b/kernel/include/onyx/exceptions.h
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2019 Pedro Falcato
- * This file is part of Carbon, and is released under the terms of the MIT License
+ * This file is part of Carbon, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  */
 #ifndef _CARBON_EXCEPTIONS_H

--- a/kernel/include/onyx/exec.h
+++ b/kernel/include/onyx/exec.h
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2020 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  */
 #ifndef _ONYX_EXEC_H

--- a/kernel/include/onyx/expected.hpp
+++ b/kernel/include/onyx/expected.hpp
@@ -1,9 +1,9 @@
 /*
  * Copyright (c) 2020 - 2022 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  *
- * SPDX-License-Identifier: MIT
+ * SPDX-License-Identifier: GPL-2.0-only
  */
 #ifndef _ONYX_EXPECTED_HPP
 #define _ONYX_EXPECTED_HPP

--- a/kernel/include/onyx/file.h
+++ b/kernel/include/onyx/file.h
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2017 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  */
 #ifndef _ONYX_FILE_H

--- a/kernel/include/onyx/filemap.h
+++ b/kernel/include/onyx/filemap.h
@@ -1,9 +1,9 @@
 /*
  * Copyright (c) 2023 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  *
- * SPDX-License-Identifier: MIT
+ * SPDX-License-Identifier: GPL-2.0-only
  */
 #ifndef _ONYX_FILEMAP_H
 #define _ONYX_FILEMAP_H

--- a/kernel/include/onyx/flock.h
+++ b/kernel/include/onyx/flock.h
@@ -1,9 +1,9 @@
 /*
  * Copyright (c) 2024 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  *
- * SPDX-License-Identifier: MIT
+ * SPDX-License-Identifier: GPL-2.0-only
  */
 
 #ifndef _ONYX_FLOCK_H

--- a/kernel/include/onyx/fnv.h
+++ b/kernel/include/onyx/fnv.h
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2017 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  */
 #ifndef _KERNEL_FNV_H

--- a/kernel/include/onyx/font.h
+++ b/kernel/include/onyx/font.h
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2018 Pedro Falcato
- * This file is part of Carbon, and is released under the terms of the MIT License
+ * This file is part of Carbon, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  */
 

--- a/kernel/include/onyx/fpu.h
+++ b/kernel/include/onyx/fpu.h
@@ -1,9 +1,9 @@
 /*
  * Copyright (c) 2016 - 2022 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  *
- * SPDX-License-Identifier: MIT
+ * SPDX-License-Identifier: GPL-2.0-only
  */
 
 #ifndef _ONYX_FPU_H

--- a/kernel/include/onyx/framebuffer.h
+++ b/kernel/include/onyx/framebuffer.h
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2018 Pedro Falcato
- * This file is part of Carbon, and is released under the terms of the MIT License
+ * This file is part of Carbon, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  */
 

--- a/kernel/include/onyx/fs_mount.h
+++ b/kernel/include/onyx/fs_mount.h
@@ -1,9 +1,9 @@
 /*
  * Copyright (c) 2016 - 2022 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  *
- * SPDX-License-Identifier: MIT
+ * SPDX-License-Identifier: GPL-2.0-only
  */
 #ifndef _ONYX_PARTITIONS_H
 #define _ONYX_PARTITIONS_H

--- a/kernel/include/onyx/futex.h
+++ b/kernel/include/onyx/futex.h
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2017 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  */
 #ifndef _KERNEL_FUTEX_H

--- a/kernel/include/onyx/generic/platform/jump_label.h
+++ b/kernel/include/onyx/generic/platform/jump_label.h
@@ -1,9 +1,9 @@
 /*
  * Copyright (c) 2023 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  *
- * SPDX-License-Identifier: MIT
+ * SPDX-License-Identifier: GPL-2.0-only
  */
 #ifndef _ONYX_GENERIC_PLATFORM_JUMP_LABEL_H
 #define _ONYX_GENERIC_PLATFORM_JUMP_LABEL_H

--- a/kernel/include/onyx/gpt.h
+++ b/kernel/include/onyx/gpt.h
@@ -1,9 +1,9 @@
 /*
  * Copyright (c) 2017 - 2022 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  *
- * SPDX-License-Identifier: MIT
+ * SPDX-License-Identifier: GPL-2.0-only
  */
 #ifndef _ONYX_GPT_H
 #define _ONYX_GPT_H

--- a/kernel/include/onyx/groups.h
+++ b/kernel/include/onyx/groups.h
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2020 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  */
 #ifndef _ONYX_GROUPS_H

--- a/kernel/include/onyx/handle.h
+++ b/kernel/include/onyx/handle.h
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2021 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  */
 #ifndef _ONYX_HANDLE_H

--- a/kernel/include/onyx/hashtable.hpp
+++ b/kernel/include/onyx/hashtable.hpp
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2019 Pedro Falcato
- * This file is part of Carbon, and is released under the terms of the MIT License
+ * This file is part of Carbon, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  */
 

--- a/kernel/include/onyx/hwregister.hpp
+++ b/kernel/include/onyx/hwregister.hpp
@@ -1,9 +1,9 @@
 /*
  * Copyright (c) 2019 - 2023 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  *
- * SPDX-License-Identifier: MIT
+ * SPDX-License-Identifier: GPL-2.0-only
  */
 #ifndef _ONYX_HWREGISTER_HPP
 #define _ONYX_HWREGISTER_HPP

--- a/kernel/include/onyx/hybrid_lock.h
+++ b/kernel/include/onyx/hybrid_lock.h
@@ -1,9 +1,9 @@
 /*
  * Copyright (c) 2020 - 2022 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  *
- * SPDX-License-Identifier: MIT
+ * SPDX-License-Identifier: GPL-2.0-only
  */
 
 #ifndef _ONYX_HYBRID_LOCK_H

--- a/kernel/include/onyx/i2c.h
+++ b/kernel/include/onyx/i2c.h
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2018 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  */
 

--- a/kernel/include/onyx/id.h
+++ b/kernel/include/onyx/id.h
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2017 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  */
 #ifndef _KERNEL_ID_H

--- a/kernel/include/onyx/image.h
+++ b/kernel/include/onyx/image.h
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2021 - 2022 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  */
 #ifndef _ONYX_IMAGE_H

--- a/kernel/include/onyx/init.h
+++ b/kernel/include/onyx/init.h
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2020 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  */
 #ifndef _ONYX_INIT_H

--- a/kernel/include/onyx/initrd.h
+++ b/kernel/include/onyx/initrd.h
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2016, 2017 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  */
 #ifndef _INITRD_H

--- a/kernel/include/onyx/input/device.h
+++ b/kernel/include/onyx/input/device.h
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2020 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  */
 #ifndef _ONYX_INPUT_DEVICE_H

--- a/kernel/include/onyx/input/event.h
+++ b/kernel/include/onyx/input/event.h
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2020 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  */
 #ifndef _ONYX_INPUT_EVENT_H

--- a/kernel/include/onyx/input/keys.h
+++ b/kernel/include/onyx/input/keys.h
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2017 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  */
 #ifndef _ONYX_INPUT_KEYS_H

--- a/kernel/include/onyx/input/state.h
+++ b/kernel/include/onyx/input/state.h
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2020 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  */
 #ifndef _ONYX_INPUT_STATE_H

--- a/kernel/include/onyx/integral_constant.h
+++ b/kernel/include/onyx/integral_constant.h
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2021 Pedro Falcato
- * This file is part of Onyx and is released under the terms of the MIT License
+ * This file is part of Onyx and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  */
 #ifndef _ONYX_INTEGRAL_CONSTANT_H

--- a/kernel/include/onyx/internal_abi.h
+++ b/kernel/include/onyx/internal_abi.h
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2021 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  */
 

--- a/kernel/include/onyx/interval_tree.h
+++ b/kernel/include/onyx/interval_tree.h
@@ -1,9 +1,9 @@
 /*
  * Copyright (c) 2023 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  *
- * SPDX-License-Identifier: MIT
+ * SPDX-License-Identifier: GPL-2.0-only
  */
 #ifndef _ONYX_INTERVAL_TREE_H
 #define _ONYX_INTERVAL_TREE_H

--- a/kernel/include/onyx/intrinsics.h
+++ b/kernel/include/onyx/intrinsics.h
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2021 - 2022 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  */
 

--- a/kernel/include/onyx/ioctx.h
+++ b/kernel/include/onyx/ioctx.h
@@ -1,9 +1,9 @@
 /*
  * Copyright (c) 2016 - 2023 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  *
- * SPDX-License-Identifier: MIT
+ * SPDX-License-Identifier: GPL-2.0-only
  */
 #ifndef _IOCTX_H
 #define _IOCTX_H

--- a/kernel/include/onyx/iovec_iter.h
+++ b/kernel/include/onyx/iovec_iter.h
@@ -1,9 +1,9 @@
 /*
  * Copyright (c) 2023 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  *
- * SPDX-License-Identifier: MIT
+ * SPDX-License-Identifier: GPL-2.0-only
  */
 #ifndef _ONYX_IOVEC_ITER_H
 #define _ONYX_IOVEC_ITER_H

--- a/kernel/include/onyx/irq.h
+++ b/kernel/include/onyx/irq.h
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2016, 2017 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  */
 

--- a/kernel/include/onyx/is_integral.h
+++ b/kernel/include/onyx/is_integral.h
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2019 Pedro Falcato
- * This file is part of Carbon, and is released under the terms of the MIT License
+ * This file is part of Carbon, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  */
 #ifndef _CARBON_IS_INTEGRAL_H

--- a/kernel/include/onyx/itimer.h
+++ b/kernel/include/onyx/itimer.h
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2020 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  */
 #ifndef _ONYX_ITIMER_H

--- a/kernel/include/onyx/kcov.h
+++ b/kernel/include/onyx/kcov.h
@@ -1,9 +1,9 @@
 /*
  * Copyright (c) 2023 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  *
- * SPDX-License-Identifier: MIT
+ * SPDX-License-Identifier: GPL-2.0-only
  */
 
 #ifndef _ONYX_KCOV_H

--- a/kernel/include/onyx/ktrace.h
+++ b/kernel/include/onyx/ktrace.h
@@ -1,9 +1,9 @@
 /*
  * Copyright (c) 2020 - 2023 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  *
- * SPDX-License-Identifier: MIT
+ * SPDX-License-Identifier: GPL-2.0-only
  */
 
 #ifndef _ONYX_KTRACE_H

--- a/kernel/include/onyx/kunit.h
+++ b/kernel/include/onyx/kunit.h
@@ -3,10 +3,10 @@
  * Copyright 2016 The Fuchsia Authors
  * Copyright (c) 2013, Google, Inc. All rights reserved
 
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  *
- * SPDX-License-Identifier: MIT
+ * SPDX-License-Identifier: GPL-2.0-only
  *
  * Note: The checks themselves (UTCHECK*, EXPECT* and ASSERT*) were taken from
  * Fuchsia, also MIT licensed. This is the only thing written by Google/Fuchsia Authors

--- a/kernel/include/onyx/libfs.h
+++ b/kernel/include/onyx/libfs.h
@@ -1,9 +1,9 @@
 /*
  * Copyright (c) 2024 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  *
- * SPDX-License-Identifier: MIT
+ * SPDX-License-Identifier: GPL-2.0-only
  */
 
 #ifndef _ONYX_LIBFS_H

--- a/kernel/include/onyx/limits.h
+++ b/kernel/include/onyx/limits.h
@@ -1,9 +1,9 @@
 /*
  * Copyright (c) 2021 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  *
- * SPDX-License-Identifier: MIT
+ * SPDX-License-Identifier: GPL-2.0-only
  */
 
 #ifndef _ONYX_LIMITS_H

--- a/kernel/include/onyx/linker_section.hpp
+++ b/kernel/include/onyx/linker_section.hpp
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2020 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  */
 #ifndef _ONYX_LINKER_SECTION_H

--- a/kernel/include/onyx/list.h
+++ b/kernel/include/onyx/list.h
@@ -1,9 +1,9 @@
 /*
  * Copyright (c) 2017 - 2023 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  *
- * SPDX-License-Identifier: MIT
+ * SPDX-License-Identifier: GPL-2.0-only
  */
 #ifndef _ONYX_LIST_H
 #define _ONYX_LIST_H

--- a/kernel/include/onyx/list.hpp
+++ b/kernel/include/onyx/list.hpp
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2019 Pedro Falcato
- * This file is part of Carbon, and is released under the terms of the MIT License
+ * This file is part of Carbon, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  */
 

--- a/kernel/include/onyx/local_lock.h
+++ b/kernel/include/onyx/local_lock.h
@@ -1,9 +1,9 @@
 /*
  * Copyright (c) 2024 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  *
- * SPDX-License-Identifier: MIT
+ * SPDX-License-Identifier: GPL-2.0-only
  */
 #ifndef _ONYX_LOCAL_LOCK_H
 #define _ONYX_LOCAL_LOCK_H

--- a/kernel/include/onyx/lock_annotations.h
+++ b/kernel/include/onyx/lock_annotations.h
@@ -1,9 +1,9 @@
 /*
  * Copyright (c) 2023 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  *
- * SPDX-License-Identifier: MIT
+ * SPDX-License-Identifier: GPL-2.0-only
  */
 #ifndef _ONYX_LOCK_ANNOTATIONS_H
 #define _ONYX_LOCK_ANNOTATIONS_H

--- a/kernel/include/onyx/log.h
+++ b/kernel/include/onyx/log.h
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2016, 2017 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  */
 #ifndef _KERNEL_LOG_H
@@ -26,7 +26,7 @@
            "] " x ": " __VA_ARGS__)
 
 #define LOG INFO
-#define SUBMIT_BUG_REPORT(x)                                                                      \
+#define SUBGPLv2_BUG_REPORT(x)                                                                      \
     printf("If you want this bug/feature to be fixed, open an issue at the repo's issue "         \
            "tracker(https://github.com/heatd/Onyx/issues) with a title along the lines of \"%s: " \
            "Fix x bug\". Thanks!\n",                                                              \

--- a/kernel/include/onyx/majorminor.h
+++ b/kernel/include/onyx/majorminor.h
@@ -1,9 +1,9 @@
 /*
  * Copyright (c) 2016 - 2021 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  *
- * SPDX-License-Identifier: MIT
+ * SPDX-License-Identifier: GPL-2.0-only
  */
 
 #ifndef _ONYX_MAJORMINOR_H

--- a/kernel/include/onyx/mbr.h
+++ b/kernel/include/onyx/mbr.h
@@ -1,9 +1,9 @@
 /*
  * Copyright (c) 2016 - 2022 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  *
- * SPDX-License-Identifier: MIT
+ * SPDX-License-Identifier: GPL-2.0-only
  */
 
 #ifndef _ONYX_MBR_H

--- a/kernel/include/onyx/memory.hpp
+++ b/kernel/include/onyx/memory.hpp
@@ -1,9 +1,9 @@
 /*
  * Copyright (c) 2017 - 2022 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  *
- * SPDX-License-Identifier: MIT
+ * SPDX-License-Identifier: GPL-2.0-only
  */
 #ifndef _ONYX_MEMORY_HPP
 #define _ONYX_MEMORY_HPP

--- a/kernel/include/onyx/memstream.h
+++ b/kernel/include/onyx/memstream.h
@@ -1,9 +1,9 @@
 /*
  * Copyright (c) 2022 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  *
- * SPDX-License-Identifier: MIT
+ * SPDX-License-Identifier: GPL-2.0-only
  */
 #ifndef _ONYX_MEMSTREAM_H
 #define _ONYX_MEMSTREAM_H

--- a/kernel/include/onyx/mm/amap.h
+++ b/kernel/include/onyx/mm/amap.h
@@ -1,9 +1,9 @@
 /*
  * Copyright (c) 2023 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  *
- * SPDX-License-Identifier: MIT
+ * SPDX-License-Identifier: GPL-2.0-only
  */
 #ifndef _ONYX_MM_AMAP_H
 #define _ONYX_MM_AMAP_H

--- a/kernel/include/onyx/mm/flush.h
+++ b/kernel/include/onyx/mm/flush.h
@@ -1,9 +1,9 @@
 /*
  * Copyright (c) 2019 - 2023 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  *
- * SPDX-License-Identifier: MIT
+ * SPDX-License-Identifier: GPL-2.0-only
  */
 
 #ifndef _ONYX_MM_WRITEBACK_H

--- a/kernel/include/onyx/mm/kasan.h
+++ b/kernel/include/onyx/mm/kasan.h
@@ -1,9 +1,9 @@
 /*
  * Copyright (c) 2019 - 2022 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  *
- * SPDX-License-Identifier: MIT
+ * SPDX-License-Identifier: GPL-2.0-only
  */
 
 #ifndef _MM_KASAN_H

--- a/kernel/include/onyx/mm/page_lru.h
+++ b/kernel/include/onyx/mm/page_lru.h
@@ -1,9 +1,9 @@
 /*
  * Copyright (c) 2024 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  *
- * SPDX-License-Identifier: MIT
+ * SPDX-License-Identifier: GPL-2.0-only
  */
 
 #ifndef _ONYX_MM_PAGE_LRU_H

--- a/kernel/include/onyx/mm/page_node.h
+++ b/kernel/include/onyx/mm/page_node.h
@@ -1,9 +1,9 @@
 /*
  * Copyright (c) 2017 - 2024 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  *
- * SPDX-License-Identifier: MIT
+ * SPDX-License-Identifier: GPL-2.0-only
  */
 
 #ifndef _ONYX_MM_PAGE_NODE_H

--- a/kernel/include/onyx/mm/page_zone.h
+++ b/kernel/include/onyx/mm/page_zone.h
@@ -1,9 +1,9 @@
 /*
  * Copyright (c) 2017 - 2024 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  *
- * SPDX-License-Identifier: MIT
+ * SPDX-License-Identifier: GPL-2.0-only
  */
 
 #ifndef _ONYX_MM_PAGE_ZONE_H

--- a/kernel/include/onyx/mm/pool.hpp
+++ b/kernel/include/onyx/mm/pool.hpp
@@ -1,9 +1,9 @@
 /*
  * Copyright (c) 2020 - 2023 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  *
- * SPDX-License-Identifier: MIT
+ * SPDX-License-Identifier: GPL-2.0-only
  */
 
 #ifndef _ONYX_MM_POOL_HPP

--- a/kernel/include/onyx/mm/reclaim.h
+++ b/kernel/include/onyx/mm/reclaim.h
@@ -1,9 +1,9 @@
 /*
  * Copyright (c) 2023 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  *
- * SPDX-License-Identifier: MIT
+ * SPDX-License-Identifier: GPL-2.0-only
  */
 #ifndef _ONYX_MM_RECLAIM_H
 #define _ONYX_MM_RECLAIM_H

--- a/kernel/include/onyx/mm/shmem.h
+++ b/kernel/include/onyx/mm/shmem.h
@@ -1,9 +1,9 @@
 /*
  * Copyright (c) 2023 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  *
- * SPDX-License-Identifier: MIT
+ * SPDX-License-Identifier: GPL-2.0-only
  */
 
 #ifndef _ONYX_MM_SHMEM_H

--- a/kernel/include/onyx/mm/shrinker.h
+++ b/kernel/include/onyx/mm/shrinker.h
@@ -1,9 +1,9 @@
 /*
  * Copyright (c) 2023 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  *
- * SPDX-License-Identifier: MIT
+ * SPDX-License-Identifier: GPL-2.0-only
  */
 #ifndef _ONYX_MM_SHRINKER_H
 #define _ONYX_MM_SHRINKER_H

--- a/kernel/include/onyx/mm/slab.h
+++ b/kernel/include/onyx/mm/slab.h
@@ -1,9 +1,9 @@
 /*
  * Copyright (c) 2022 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  *
- * SPDX-License-Identifier: MIT
+ * SPDX-License-Identifier: GPL-2.0-only
  */
 #ifndef _ONYX_MM_SLAB_H
 #define _ONYX_MM_SLAB_H

--- a/kernel/include/onyx/mm/vm_object.h
+++ b/kernel/include/onyx/mm/vm_object.h
@@ -1,9 +1,9 @@
 /*
  * Copyright (c) 2018 - 2024 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  *
- * SPDX-License-Identifier: MIT
+ * SPDX-License-Identifier: GPL-2.0-only
  */
 
 #ifndef _ONYX_MM_VM_OBJECT_H

--- a/kernel/include/onyx/mm_address_space.h
+++ b/kernel/include/onyx/mm_address_space.h
@@ -1,9 +1,9 @@
 /*
  * Copyright (c) 2016 - 2024 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  *
- * SPDX-License-Identifier: MIT
+ * SPDX-License-Identifier: GPL-2.0-only
  */
 #ifndef _ONYX_MM_ADDRESS_SPACE_H
 #define _ONYX_MM_ADDRESS_SPACE_H

--- a/kernel/include/onyx/module.h
+++ b/kernel/include/onyx/module.h
@@ -1,9 +1,9 @@
 /*
  * Copyright (c) 2016 - 2022 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  *
- * SPDX-License-Identifier: MIT
+ * SPDX-License-Identifier: GPL-2.0-only
  */
 #ifndef _ONYX_MODULE_H
 #define _ONYX_MODULE_H

--- a/kernel/include/onyx/modules.h
+++ b/kernel/include/onyx/modules.h
@@ -1,9 +1,9 @@
 /*
  * Copyright (c) 2016 - 2024 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  *
- * SPDX-License-Identifier: MIT
+ * SPDX-License-Identifier: GPL-2.0-only
  */
 #ifndef _ONYX_MODULES_H
 #define _ONYX_MODULES_H

--- a/kernel/include/onyx/mtable.h
+++ b/kernel/include/onyx/mtable.h
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2017 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  */
 #ifndef _KERNEL_MTABLE_H

--- a/kernel/include/onyx/mutex.h
+++ b/kernel/include/onyx/mutex.h
@@ -1,9 +1,9 @@
 /*
  * Copyright (c) 2016 - 2023 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  *
- * SPDX-License-Identifier: MIT
+ * SPDX-License-Identifier: GPL-2.0-only
  */
 #ifndef _ONYX_MUTEX_H
 #define _ONYX_MUTEX_H

--- a/kernel/include/onyx/namei.h
+++ b/kernel/include/onyx/namei.h
@@ -1,10 +1,10 @@
 
 /*
  * Copyright (c) 2020 - 2023 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  *
- * SPDX-License-Identifier: MIT
+ * SPDX-License-Identifier: GPL-2.0-only
  */
 #ifndef _ONYX_NAMEI_H
 #define _ONYX_NAMEI_H

--- a/kernel/include/onyx/net/arp.h
+++ b/kernel/include/onyx/net/arp.h
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2016, 2017 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  */
 

--- a/kernel/include/onyx/net/dll.h
+++ b/kernel/include/onyx/net/dll.h
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2020 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  */
 #ifndef _ONYX_NET_DLL_H

--- a/kernel/include/onyx/net/ethernet.h
+++ b/kernel/include/onyx/net/ethernet.h
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2016, 2017 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  */
 

--- a/kernel/include/onyx/net/icmp.h
+++ b/kernel/include/onyx/net/icmp.h
@@ -1,9 +1,9 @@
 /*
  * Copyright (c) 2016 - 2022 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  *
- * SPDX-License-Identifier: MIT
+ * SPDX-License-Identifier: GPL-2.0-only
  */
 #ifndef _ONYX_NET_ICMP_H
 #define _ONYX_NET_ICMP_H

--- a/kernel/include/onyx/net/icmpv6.h
+++ b/kernel/include/onyx/net/icmpv6.h
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2020 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  */
 #ifndef _ONYX_NET_ICMPV6_H

--- a/kernel/include/onyx/net/inet_cork.h
+++ b/kernel/include/onyx/net/inet_cork.h
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2020 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  */
 

--- a/kernel/include/onyx/net/inet_csum.h
+++ b/kernel/include/onyx/net/inet_csum.h
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2020 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  */
 

--- a/kernel/include/onyx/net/inet_packet_flow.h
+++ b/kernel/include/onyx/net/inet_packet_flow.h
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2020 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  */
 

--- a/kernel/include/onyx/net/inet_proto.h
+++ b/kernel/include/onyx/net/inet_proto.h
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2020 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  */
 

--- a/kernel/include/onyx/net/inet_proto_family.h
+++ b/kernel/include/onyx/net/inet_proto_family.h
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2020 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  */
 #ifndef _ONYX_NET_INET_PROTO_FAMILY_H

--- a/kernel/include/onyx/net/inet_route.h
+++ b/kernel/include/onyx/net/inet_route.h
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2020 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  */
 

--- a/kernel/include/onyx/net/inet_sock_addr.h
+++ b/kernel/include/onyx/net/inet_sock_addr.h
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2020 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  */
 

--- a/kernel/include/onyx/net/inet_socket.h
+++ b/kernel/include/onyx/net/inet_socket.h
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2020 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  */
 

--- a/kernel/include/onyx/net/ip.h
+++ b/kernel/include/onyx/net/ip.h
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2016-2020 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  */
 #ifndef _ONYX_NET_IP_H

--- a/kernel/include/onyx/net/ipv6.h
+++ b/kernel/include/onyx/net/ipv6.h
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2020 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  */
 

--- a/kernel/include/onyx/net/ndp.h
+++ b/kernel/include/onyx/net/ndp.h
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2020 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  */
 

--- a/kernel/include/onyx/net/neighbour.h
+++ b/kernel/include/onyx/net/neighbour.h
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2020 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  */
 

--- a/kernel/include/onyx/net/netif.h
+++ b/kernel/include/onyx/net/netif.h
@@ -1,9 +1,9 @@
 /*
  * Copyright (c) 2017 - 2022 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  *
- * SPDX-License-Identifier: MIT
+ * SPDX-License-Identifier: GPL-2.0-only
  */
 
 #ifndef _ONYX_NET_NETIF_H

--- a/kernel/include/onyx/net/netkernel.h
+++ b/kernel/include/onyx/net/netkernel.h
@@ -1,9 +1,9 @@
 /*
  * Copyright (c) 2020 - 2022 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  *
- * SPDX-License-Identifier: MIT
+ * SPDX-License-Identifier: GPL-2.0-only
  */
 
 #ifndef _ONYX_NET_NETKERNEL_H

--- a/kernel/include/onyx/net/network.h
+++ b/kernel/include/onyx/net/network.h
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2016, 2017 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  */
 #ifndef _ONYX_NET_NETWORK_H

--- a/kernel/include/onyx/net/proto_family.h
+++ b/kernel/include/onyx/net/proto_family.h
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2020 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  */
 #ifndef _ONYX_NET_PROTO_FAMILY_H

--- a/kernel/include/onyx/net/socket.h
+++ b/kernel/include/onyx/net/socket.h
@@ -1,9 +1,9 @@
 /*
  * Copyright (c) 2018 - 2022 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  *
- * SPDX-License-Identifier: MIT
+ * SPDX-License-Identifier: GPL-2.0-only
  */
 
 #ifndef _ONYX_NET_SOCKET_H

--- a/kernel/include/onyx/net/socket_table.h
+++ b/kernel/include/onyx/net/socket_table.h
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2020 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  */
 

--- a/kernel/include/onyx/net/tcp.h
+++ b/kernel/include/onyx/net/tcp.h
@@ -1,9 +1,9 @@
 /*
  * Copyright (c) 2020 - 2022 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  *
- * SPDX-License-Identifier: MIT
+ * SPDX-License-Identifier: GPL-2.0-only
  */
 #ifndef _ONYX_NET_TCP_H
 #define _ONYX_NET_TCP_H
@@ -57,7 +57,7 @@ struct tcp_header
 #define TCP_OPTION_NOP            (1)
 #define TCP_OPTION_MSS            (2)
 #define TCP_OPTION_WINDOW_SCALE   (3)
-#define TCP_OPTION_SACK_PERMITTED (4)
+#define TCP_OPTION_SACK_PERGPLv2TED (4)
 #define TCP_OPTION_SACK           (5)
 #define TCP_OPTION_TIMESTAMP      (8)
 

--- a/kernel/include/onyx/net/udp.h
+++ b/kernel/include/onyx/net/udp.h
@@ -1,9 +1,9 @@
 /*
  * Copyright (c) 2016 - 2022 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  *
- * SPDX-License-Identifier: MIT
+ * SPDX-License-Identifier: GPL-2.0-only
  */
 #ifndef _ONYX_NET_UDP_H
 #define _ONYX_NET_UDP_H

--- a/kernel/include/onyx/new.h
+++ b/kernel/include/onyx/new.h
@@ -1,9 +1,9 @@
 /*
  * Copyright (c) 2019 - 2022 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  *
- * SPDX-License-Identifier: MIT
+ * SPDX-License-Identifier: GPL-2.0-only
  */
 
 #ifndef _ONYX_NEW_H

--- a/kernel/include/onyx/no_port_io.h
+++ b/kernel/include/onyx/no_port_io.h
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2021 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  */
 

--- a/kernel/include/onyx/object.h
+++ b/kernel/include/onyx/object.h
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2018 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  */
 

--- a/kernel/include/onyx/packetbuf.h
+++ b/kernel/include/onyx/packetbuf.h
@@ -1,9 +1,9 @@
 /*
  * Copyright (c) 2020 - 2022 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  *
- * SPDX-License-Identifier: MIT
+ * SPDX-License-Identifier: GPL-2.0-only
  */
 
 #ifndef _ONYX_PACKETBUF_H

--- a/kernel/include/onyx/page.h
+++ b/kernel/include/onyx/page.h
@@ -1,9 +1,9 @@
 /*
  * Copyright (c) 2016 - 2024 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  *
- * SPDX-License-Identifier: MIT
+ * SPDX-License-Identifier: GPL-2.0-only
  */
 
 #ifndef _ONYX_PAGE_H

--- a/kernel/include/onyx/page_iov.h
+++ b/kernel/include/onyx/page_iov.h
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2020 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  */
 

--- a/kernel/include/onyx/pagecache.h
+++ b/kernel/include/onyx/pagecache.h
@@ -1,9 +1,9 @@
 /*
  * Copyright (c) 2016 - 2023 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  *
- * SPDX-License-Identifier: MIT
+ * SPDX-License-Identifier: GPL-2.0-only
  */
 
 #ifndef _PAGECACHE_H

--- a/kernel/include/onyx/paging.h
+++ b/kernel/include/onyx/paging.h
@@ -1,9 +1,9 @@
 /*
  * Copyright (c) 2016 - 2023 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  *
- * SPDX-License-Identifier: MIT
+ * SPDX-License-Identifier: GPL-2.0-only
  */
 #ifndef _PAGING_H
 #define _PAGING_H

--- a/kernel/include/onyx/pair.hpp
+++ b/kernel/include/onyx/pair.hpp
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2019 Pedro Falcato
- * This file is part of Carbon, and is released under the terms of the MIT License
+ * This file is part of Carbon, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  */
 

--- a/kernel/include/onyx/panic.h
+++ b/kernel/include/onyx/panic.h
@@ -1,9 +1,9 @@
 /*
  * Copyright (c) 2016 - 2023 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  *
- * SPDX-License-Identifier: MIT
+ * SPDX-License-Identifier: GPL-2.0-only
  */
 #ifndef _ONYX_PANIC_H
 #define _ONYX_PANIC_H

--- a/kernel/include/onyx/percpu.h
+++ b/kernel/include/onyx/percpu.h
@@ -1,9 +1,9 @@
 /*
  * Copyright (c) 2019 - 2023 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  *
- * SPDX-License-Identifier: MIT
+ * SPDX-License-Identifier: GPL-2.0-only
  */
 #ifndef _ONYX_PERCPU_H
 #define _ONYX_PERCPU_H

--- a/kernel/include/onyx/perf_probe.h
+++ b/kernel/include/onyx/perf_probe.h
@@ -1,9 +1,9 @@
 /*
  * Copyright (c) 2022 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  *
- * SPDX-License-Identifier: MIT
+ * SPDX-License-Identifier: GPL-2.0-only
  */
 #ifndef _ONYX_PERF_PROBE_H
 #define _ONYX_PERF_PROBE_H

--- a/kernel/include/onyx/photon-cookies.h
+++ b/kernel/include/onyx/photon-cookies.h
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2018 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  */
 

--- a/kernel/include/onyx/photon.h
+++ b/kernel/include/onyx/photon.h
@@ -1,9 +1,9 @@
 /*
  * Copyright (c) 2018 - 2021 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  *
- * SPDX-License-Identifier: MIT
+ * SPDX-License-Identifier: GPL-2.0-only
  */
 
 #ifndef _ONYX_PHOTON_H

--- a/kernel/include/onyx/pid.h
+++ b/kernel/include/onyx/pid.h
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2020 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  */
 

--- a/kernel/include/onyx/platform.h
+++ b/kernel/include/onyx/platform.h
@@ -1,9 +1,9 @@
 /*
  * Copyright (c) 2017 - 2021 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  *
- * SPDX-License-Identifier: MIT
+ * SPDX-License-Identifier: GPL-2.0-only
  */
 
 #ifndef _ONYX_PLATFORM_H

--- a/kernel/include/onyx/poll.h
+++ b/kernel/include/onyx/poll.h
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2019 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  */
 

--- a/kernel/include/onyx/port_io.h
+++ b/kernel/include/onyx/port_io.h
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2020 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  */
 

--- a/kernel/include/onyx/power_management.h
+++ b/kernel/include/onyx/power_management.h
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2020 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  */
 

--- a/kernel/include/onyx/preempt.h
+++ b/kernel/include/onyx/preempt.h
@@ -1,9 +1,9 @@
 /*
  * Copyright (c) 2016 - 2023 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  *
- * SPDX-License-Identifier: MIT
+ * SPDX-License-Identifier: GPL-2.0-only
  */
 #ifndef _ONYX_PREEMPT_H
 #define _ONYX_PREEMPT_H

--- a/kernel/include/onyx/proc_event.h
+++ b/kernel/include/onyx/proc_event.h
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2017 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  */
 #include <proc_event.h>

--- a/kernel/include/onyx/process.h
+++ b/kernel/include/onyx/process.h
@@ -1,9 +1,9 @@
 /*
  * Copyright (c) 2016 - 2024 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  *
- * SPDX-License-Identifier: MIT
+ * SPDX-License-Identifier: GPL-2.0-only
  */
 
 #ifndef _ONYX_PROCESS_H

--- a/kernel/include/onyx/pseudo.h
+++ b/kernel/include/onyx/pseudo.h
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2018 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  */
 

--- a/kernel/include/onyx/ptrace.h
+++ b/kernel/include/onyx/ptrace.h
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2017 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  */
 

--- a/kernel/include/onyx/radix.h
+++ b/kernel/include/onyx/radix.h
@@ -1,9 +1,9 @@
 /*
  * Copyright (c) 2022 - 2023 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  *
- * SPDX-License-Identifier: MIT
+ * SPDX-License-Identifier: GPL-2.0-only
  */
 #ifndef _ONYX_RADIX_H
 #define _ONYX_RADIX_H

--- a/kernel/include/onyx/random.h
+++ b/kernel/include/onyx/random.h
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2016, 2017 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  */
 #ifndef _RANDOM_H

--- a/kernel/include/onyx/rbtree.hpp
+++ b/kernel/include/onyx/rbtree.hpp
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2020 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  */
 

--- a/kernel/include/onyx/rbtree_iterator.hpp
+++ b/kernel/include/onyx/rbtree_iterator.hpp
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2020 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  */
 #ifndef _CARBON_RBTREE_ITER_HPP

--- a/kernel/include/onyx/rculist.h
+++ b/kernel/include/onyx/rculist.h
@@ -1,9 +1,9 @@
 /*
  * Copyright (c) 2024 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  *
- * SPDX-License-Identifier: MIT
+ * SPDX-License-Identifier: GPL-2.0-only
  */
 #ifndef _ONYX_RCULIST_H
 #define _ONYX_RCULIST_H

--- a/kernel/include/onyx/rcupdate.h
+++ b/kernel/include/onyx/rcupdate.h
@@ -1,8 +1,8 @@
 /*
  * Copyright (c) 2023 - 2024 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the LGPL-2.0-only license.
+ * This file is part of Onyx, and is released under the terms of the GPLv2 license.
  *
- * SPDX-License-Identifier: LGPL-2.0-only
+ * SPDX-License-Identifier: GPL-2.0-only
  */
 #ifndef _ONYX_RCUPDATE_H
 #define _ONYX_RCUPDATE_H

--- a/kernel/include/onyx/readahead.h
+++ b/kernel/include/onyx/readahead.h
@@ -1,9 +1,9 @@
 /*
  * Copyright (c) 2024 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  *
- * SPDX-License-Identifier: MIT
+ * SPDX-License-Identifier: GPL-2.0-only
  */
 #ifndef _ONYX_READAHEAD_H
 #define _ONYX_READAHEAD_H

--- a/kernel/include/onyx/ref.h
+++ b/kernel/include/onyx/ref.h
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2018 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  */
 

--- a/kernel/include/onyx/refcount.h
+++ b/kernel/include/onyx/refcount.h
@@ -1,9 +1,9 @@
 /*
  * Copyright (c) 2019 - 2023 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  *
- * SPDX-License-Identifier: MIT
+ * SPDX-License-Identifier: GPL-2.0-only
  */
 #ifndef _CARBON_REFCOUNT_H
 #define _CARBON_REFCOUNT_H

--- a/kernel/include/onyx/registers.h
+++ b/kernel/include/onyx/registers.h
@@ -1,9 +1,9 @@
 /*
  * Copyright (c) 2016 - 2022 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  *
- * SPDX-License-Identifier: MIT
+ * SPDX-License-Identifier: GPL-2.0-only
  */
 #ifndef _ONYX_REGISTERS_H
 #define _ONYX_REGISTERS_H

--- a/kernel/include/onyx/remove_extent.h
+++ b/kernel/include/onyx/remove_extent.h
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2019 Pedro Falcato
- * This file is part of Carbon, and is released under the terms of the MIT License
+ * This file is part of Carbon, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  */
 

--- a/kernel/include/onyx/riscv/features.h
+++ b/kernel/include/onyx/riscv/features.h
@@ -1,9 +1,9 @@
 /*
  * Copyright (c) 2022 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  *
- * SPDX-License-Identifier: MIT
+ * SPDX-License-Identifier: GPL-2.0-only
  */
 
 #ifndef _ONYX_RISCV_FEATURES_H

--- a/kernel/include/onyx/riscv/include/platform/atomic.h
+++ b/kernel/include/onyx/riscv/include/platform/atomic.h
@@ -1,9 +1,9 @@
 /*
  * Copyright (c) 2024 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  *
- * SPDX-License-Identifier: MIT
+ * SPDX-License-Identifier: GPL-2.0-only
  */
 
 #define smp_rmb() __asm__ __volatile__("fence r,r" ::: "memory")

--- a/kernel/include/onyx/riscv/include/platform/elf.h
+++ b/kernel/include/onyx/riscv/include/platform/elf.h
@@ -1,9 +1,9 @@
 /*
  * Copyright (c) 2022 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  *
- * SPDX-License-Identifier: MIT
+ * SPDX-License-Identifier: GPL-2.0-only
  */
 #ifndef ONYX_RISCV_INCLUDE_PLATFORM_ELF_H
 #define ONYX_RISCV_INCLUDE_PLATFORM_ELF_H

--- a/kernel/include/onyx/riscv/include/platform/internal_abi.h
+++ b/kernel/include/onyx/riscv/include/platform/internal_abi.h
@@ -1,9 +1,9 @@
 /*
  * Copyright (c) 2021 - 2022 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  *
- * SPDX-License-Identifier: MIT
+ * SPDX-License-Identifier: GPL-2.0-only
  */
 #ifndef _ONYX_RISCV_PLATFORM_INTERNAL_ABI_H
 #define _ONYX_RISCV_PLATFORM_INTERNAL_ABI_H

--- a/kernel/include/onyx/riscv/include/platform/irq.h
+++ b/kernel/include/onyx/riscv/include/platform/irq.h
@@ -1,9 +1,9 @@
 /*
  * Copyright (c) 2021 - 2022 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  *
- * SPDX-License-Identifier: MIT
+ * SPDX-License-Identifier: GPL-2.0-only
  */
 
 #ifndef _ONYX_RISCV_PLATFORM_IRQ_H

--- a/kernel/include/onyx/riscv/include/platform/jump_label.h
+++ b/kernel/include/onyx/riscv/include/platform/jump_label.h
@@ -1,9 +1,9 @@
 /*
  * Copyright (c) 2023 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  *
- * SPDX-License-Identifier: MIT
+ * SPDX-License-Identifier: GPL-2.0-only
  */
 #ifndef _ONYX_RISCV_PLATFORM_JUMP_LABEL_H
 #define _ONYX_RISCV_PLATFORM_JUMP_LABEL_H

--- a/kernel/include/onyx/riscv/include/platform/page.h
+++ b/kernel/include/onyx/riscv/include/platform/page.h
@@ -1,9 +1,9 @@
 /*
  * Copyright (c) 2021 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  *
- * SPDX-License-Identifier: MIT
+ * SPDX-License-Identifier: GPL-2.0-only
  */
 
 #ifndef _ONYX_RISCV_PAGE_H

--- a/kernel/include/onyx/riscv/include/platform/syscall.h
+++ b/kernel/include/onyx/riscv/include/platform/syscall.h
@@ -1,9 +1,9 @@
 /*
  * Copyright (c) 2021 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  *
- * SPDX-License-Identifier: MIT
+ * SPDX-License-Identifier: GPL-2.0-only
  */
 
 #ifndef _ONYX_RISCV_PLATFORM_SYSCALL_H

--- a/kernel/include/onyx/riscv/include/platform/vm.h
+++ b/kernel/include/onyx/riscv/include/platform/vm.h
@@ -1,9 +1,9 @@
 /*
  * Copyright (c) 2021 - 2023 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  *
- * SPDX-License-Identifier: MIT
+ * SPDX-License-Identifier: GPL-2.0-only
  */
 
 #ifndef _ONYX_RISCV_PLATFORM_VM_H

--- a/kernel/include/onyx/riscv/include/platform/vm_layout.h
+++ b/kernel/include/onyx/riscv/include/platform/vm_layout.h
@@ -1,9 +1,9 @@
 /*
  * Copyright (c) 2021 - 2023 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  *
- * SPDX-License-Identifier: MIT
+ * SPDX-License-Identifier: GPL-2.0-only
  */
 
 #ifndef _ONYX_RISCV_PLATFORM_VM_LAYOUT_H

--- a/kernel/include/onyx/riscv/intrinsics.h
+++ b/kernel/include/onyx/riscv/intrinsics.h
@@ -1,9 +1,9 @@
 /*
  * Copyright (c) 2021 - 2022 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  *
- * SPDX-License-Identifier: MIT
+ * SPDX-License-Identifier: GPL-2.0-only
  */
 
 #ifndef _ONYX_RISCV_INTRINSICS_H

--- a/kernel/include/onyx/riscv/percpu.h
+++ b/kernel/include/onyx/riscv/percpu.h
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2021 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  */
 

--- a/kernel/include/onyx/riscv/sbi.h
+++ b/kernel/include/onyx/riscv/sbi.h
@@ -1,9 +1,9 @@
 /*
  * Copyright (c) 2022 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  *
- * SPDX-License-Identifier: MIT
+ * SPDX-License-Identifier: GPL-2.0-only
  */
 #ifndef _ONYX_RISCV_SBI_H
 #define _ONYX_RISCV_SBI_H

--- a/kernel/include/onyx/riscv/signal.h
+++ b/kernel/include/onyx/riscv/signal.h
@@ -1,9 +1,9 @@
 /*
  * Copyright (c) 2019 - 2023 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  *
- * SPDX-License-Identifier: MIT
+ * SPDX-License-Identifier: GPL-2.0-only
  */
 
 #ifndef _ONYX_RISCV_SIGNAL_H

--- a/kernel/include/onyx/riscv/smp.h
+++ b/kernel/include/onyx/riscv/smp.h
@@ -1,9 +1,9 @@
 /*
  * Copyright (c) 2023 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  *
- * SPDX-License-Identifier: MIT
+ * SPDX-License-Identifier: GPL-2.0-only
  */
 #ifndef _ONYX_RISCV_SMP_H
 #define _ONYX_RISCV_SMP_H

--- a/kernel/include/onyx/rwlock.h
+++ b/kernel/include/onyx/rwlock.h
@@ -1,9 +1,9 @@
 /*
  * Copyright (c) 2017 - 2023 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  *
- * SPDX-License-Identifier: MIT
+ * SPDX-License-Identifier: GPL-2.0-only
  */
 #ifndef _ONYX_RWLOCK_H
 #define _ONYX_RWLOCK_H

--- a/kernel/include/onyx/scheduler.h
+++ b/kernel/include/onyx/scheduler.h
@@ -1,9 +1,9 @@
 /*
  * Copyright (c) 2016 - 2024 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  *
- * SPDX-License-Identifier: MIT
+ * SPDX-License-Identifier: GPL-2.0-only
  */
 #ifndef _ONYX_SCHEDULER_H
 #define _ONYX_SCHEDULER_H

--- a/kernel/include/onyx/scoped_lock.h
+++ b/kernel/include/onyx/scoped_lock.h
@@ -1,9 +1,9 @@
 /*
  * Copyright (c) 2019 - 2023 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  *
- * SPDX-License-Identifier: MIT
+ * SPDX-License-Identifier: GPL-2.0-only
  */
 
 #ifndef _ONYX_SCOPED_LOCK_H

--- a/kernel/include/onyx/semaphore.h
+++ b/kernel/include/onyx/semaphore.h
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2018 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  */
 #ifndef _ONYX_SEM_H

--- a/kernel/include/onyx/serial.h
+++ b/kernel/include/onyx/serial.h
@@ -1,9 +1,9 @@
 /*
  * Copyright (c) 2020 - 2022 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  *
- * SPDX-License-Identifier: MIT
+ * SPDX-License-Identifier: GPL-2.0-only
  */
 
 #ifndef _ONYX_SERIAL_H

--- a/kernel/include/onyx/signal.h
+++ b/kernel/include/onyx/signal.h
@@ -1,9 +1,9 @@
 /*
  * Copyright (c) 2016 - 2023 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  *
- * SPDX-License-Identifier: MIT
+ * SPDX-License-Identifier: GPL-2.0-only
  */
 
 #ifndef _ONYX_SIGNAL_H

--- a/kernel/include/onyx/slice.hpp
+++ b/kernel/include/onyx/slice.hpp
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2020 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIType License
+ * This file is part of Onyx, and is released under the terms of the GPLv2ype License
  * check LICENSE at the root directory for more information
  */
 #ifndef _ONYX_SLICE_HPP

--- a/kernel/include/onyx/smbios.h
+++ b/kernel/include/onyx/smbios.h
@@ -1,9 +1,9 @@
 /*
  * Copyright (c) 2016 - 2023 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  *
- * SPDX-License-Identifier: MIT
+ * SPDX-License-Identifier: GPL-2.0-only
  */
 #ifndef _ONYX_SMBIOS_H
 #define _ONYX_SMBIOS_H

--- a/kernel/include/onyx/smp.h
+++ b/kernel/include/onyx/smp.h
@@ -1,9 +1,9 @@
 /*
  * Copyright (c) 2019 - 2022 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  *
- * SPDX-License-Identifier: MIT
+ * SPDX-License-Identifier: GPL-2.0-only
  */
 #ifndef _CARBON_SMP_H
 #define _CARBON_SMP_H

--- a/kernel/include/onyx/smp_sync_control.h
+++ b/kernel/include/onyx/smp_sync_control.h
@@ -1,9 +1,9 @@
 /*
  * Copyright (c) 2020 - 2023 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  *
- * SPDX-License-Identifier: MIT
+ * SPDX-License-Identifier: GPL-2.0-only
  */
 
 #ifndef _ONYX_SMP_SYNC_CONTROL_H

--- a/kernel/include/onyx/softirq.h
+++ b/kernel/include/onyx/softirq.h
@@ -1,9 +1,9 @@
 /*
  * Copyright (c) 2020 - 2023 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  *
- * SPDX-License-Identifier: MIT
+ * SPDX-License-Identifier: GPL-2.0-only
  */
 #ifndef _ONYX_SOFTIRQ_H
 #define _ONYX_SOFTIRQ_H

--- a/kernel/include/onyx/spinlock.h
+++ b/kernel/include/onyx/spinlock.h
@@ -1,9 +1,9 @@
 /*
  * Copyright (c) 2016 - 2023 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  *
- * SPDX-License-Identifier: MIT
+ * SPDX-License-Identifier: GPL-2.0-only
  */
 #ifndef _ONYX_SPINLOCK_H
 #define _ONYX_SPINLOCK_H

--- a/kernel/include/onyx/stackdepot.h
+++ b/kernel/include/onyx/stackdepot.h
@@ -1,9 +1,9 @@
 /*
  * Copyright (c) 2023 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  *
- * SPDX-License-Identifier: MIT
+ * SPDX-License-Identifier: GPL-2.0-only
  */
 #ifndef _ONYX_STACKDEPOT_H
 #define _ONYX_STACKDEPOT_H

--- a/kernel/include/onyx/static_key.h
+++ b/kernel/include/onyx/static_key.h
@@ -1,9 +1,9 @@
 /*
  * Copyright (c) 2023 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  *
- * SPDX-License-Identifier: MIT
+ * SPDX-License-Identifier: GPL-2.0-only
  */
 
 #ifndef _ONYX_STATIC_KEY_H

--- a/kernel/include/onyx/stream.h
+++ b/kernel/include/onyx/stream.h
@@ -1,9 +1,9 @@
 /*
  * Copyright (c) 2022 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  *
- * SPDX-License-Identifier: MIT
+ * SPDX-License-Identifier: GPL-2.0-only
  */
 #ifndef _ONYX_STREAM_H
 #define _ONYX_STREAM_H

--- a/kernel/include/onyx/string_parsing.h
+++ b/kernel/include/onyx/string_parsing.h
@@ -1,9 +1,9 @@
 /*
  * Copyright (c) 2021 - 2022 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  *
- * SPDX-License-Identifier: MIT
+ * SPDX-License-Identifier: GPL-2.0-only
  */
 
 #ifndef _ONYX_STRING_PARSING_H

--- a/kernel/include/onyx/string_view.hpp
+++ b/kernel/include/onyx/string_view.hpp
@@ -1,9 +1,9 @@
 /*
  * Copyright (c) 2020 - 2023 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  *
- * SPDX-License-Identifier: MIT
+ * SPDX-License-Identifier: GPL-2.0-only
  */
 
 #ifndef _ONYX_STRING_VIEW_HPP

--- a/kernel/include/onyx/superblock.h
+++ b/kernel/include/onyx/superblock.h
@@ -1,9 +1,9 @@
 /*
  * Copyright (c) 2017 - 2024 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  *
- * SPDX-License-Identifier: MIT
+ * SPDX-License-Identifier: GPL-2.0-only
  */
 
 #ifndef _ONYX_SUPERBLOCK_H

--- a/kernel/include/onyx/symbol.h
+++ b/kernel/include/onyx/symbol.h
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2019 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  */
 #ifndef _ONYX_SYMBOL_H

--- a/kernel/include/onyx/syscall.h
+++ b/kernel/include/onyx/syscall.h
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2018 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  */
 

--- a/kernel/include/onyx/sysfs.h
+++ b/kernel/include/onyx/sysfs.h
@@ -1,9 +1,9 @@
 /*
  * Copyright (c) 2017 - 2021 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  *
- * SPDX-License-Identifier: MIT
+ * SPDX-License-Identifier: GPL-2.0-only
  */
 
 #ifndef _ONYX_SYSFS_H

--- a/kernel/include/onyx/task_switching.h
+++ b/kernel/include/onyx/task_switching.h
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2016, 2017 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  */
 

--- a/kernel/include/onyx/tasklet.h
+++ b/kernel/include/onyx/tasklet.h
@@ -1,9 +1,9 @@
 /*
  * Copyright (c) 2023 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  *
- * SPDX-License-Identifier: MIT
+ * SPDX-License-Identifier: GPL-2.0-only
  */
 #ifndef _ONYX_TASKLET_H
 #define _ONYX_TASKLET_H

--- a/kernel/include/onyx/thread.h
+++ b/kernel/include/onyx/thread.h
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2017 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  */
 #ifndef _KERNEL_THREAD_H

--- a/kernel/include/onyx/timer.h
+++ b/kernel/include/onyx/timer.h
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2016, 2017 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  */
 #ifndef _KERNEL_TIMER_H

--- a/kernel/include/onyx/tmpfs.h
+++ b/kernel/include/onyx/tmpfs.h
@@ -1,9 +1,9 @@
 /*
  * Copyright (c) 2016 - 2023 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  *
- * SPDX-License-Identifier: MIT
+ * SPDX-License-Identifier: GPL-2.0-only
  */
 #ifndef _ONYX_TMPFS_H
 #define _ONYX_TMPFS_H

--- a/kernel/include/onyx/trace/trace_base.h
+++ b/kernel/include/onyx/trace/trace_base.h
@@ -1,9 +1,9 @@
 /*
  * Copyright (c) 2023 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  *
- * SPDX-License-Identifier: MIT
+ * SPDX-License-Identifier: GPL-2.0-only
  */
 
 #ifndef _ONYX_TRACE_BASE_H

--- a/kernel/include/onyx/trace/tracing_buffer.h
+++ b/kernel/include/onyx/trace/tracing_buffer.h
@@ -1,9 +1,9 @@
 /*
  * Copyright (c) 2023 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  *
- * SPDX-License-Identifier: MIT
+ * SPDX-License-Identifier: GPL-2.0-only
  */
 
 #ifndef _ONYX_TRACING_BUFFER_H

--- a/kernel/include/onyx/tss.h
+++ b/kernel/include/onyx/tss.h
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2016, 2017 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  */
 #ifndef _TSS_H

--- a/kernel/include/onyx/tty.h
+++ b/kernel/include/onyx/tty.h
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2016, 2017 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  */
 #ifndef _ONYX_TTY_H

--- a/kernel/include/onyx/tuple.hpp
+++ b/kernel/include/onyx/tuple.hpp
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2020 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  */
 

--- a/kernel/include/onyx/tuple_size.hpp
+++ b/kernel/include/onyx/tuple_size.hpp
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2020 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  */
 

--- a/kernel/include/onyx/types.h
+++ b/kernel/include/onyx/types.h
@@ -1,9 +1,9 @@
 /*
  * Copyright (c) 2022 - 2023 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  *
- * SPDX-License-Identifier: MIT
+ * SPDX-License-Identifier: GPL-2.0-only
  */
 
 #ifndef _ONYX_TYPES_H

--- a/kernel/include/onyx/uname.h
+++ b/kernel/include/onyx/uname.h
@@ -1,9 +1,9 @@
 /*
  * Copyright (c) 2016 - 2022 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  *
- * SPDX-License-Identifier: MIT
+ * SPDX-License-Identifier: GPL-2.0-only
  */
 #ifndef _ONYX_UNAME_H
 #define _ONYX_UNAME_H

--- a/kernel/include/onyx/user.h
+++ b/kernel/include/onyx/user.h
@@ -1,9 +1,9 @@
 /*
  * Copyright (c) 2017 - 2022 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  *
- * SPDX-License-Identifier: MIT
+ * SPDX-License-Identifier: GPL-2.0-only
  */
 
 #ifndef _ONYX_USER_H

--- a/kernel/include/onyx/utf8.h
+++ b/kernel/include/onyx/utf8.h
@@ -1,9 +1,9 @@
 /*
  * Copyright (c) 2019 - 2022 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  *
- * SPDX-License-Identifier: MIT
+ * SPDX-License-Identifier: GPL-2.0-only
  */
 
 /* utf8.h - Contains conversions routines from utf8 to utf32 and vice-versa */

--- a/kernel/include/onyx/utfstring.h
+++ b/kernel/include/onyx/utfstring.h
@@ -1,9 +1,9 @@
 /*
  * Copyright (c) 2022 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  *
- * SPDX-License-Identifier: MIT
+ * SPDX-License-Identifier: GPL-2.0-only
  */
 
 #ifndef _ONYX_UTFSTRING_H

--- a/kernel/include/onyx/utility.hpp
+++ b/kernel/include/onyx/utility.hpp
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2019, 2020, 2021 Pedro Falcato
- * This file is part of Carbon, and is released under the terms of the MIT License
+ * This file is part of Carbon, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  */
 

--- a/kernel/include/onyx/utils.h
+++ b/kernel/include/onyx/utils.h
@@ -1,9 +1,9 @@
 /*
  * Copyright (c) 2017 - 2023 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  *
- * SPDX-License-Identifier: MIT
+ * SPDX-License-Identifier: GPL-2.0-only
  */
 
 #ifndef _ONYX_UTILS_H

--- a/kernel/include/onyx/vdso.h
+++ b/kernel/include/onyx/vdso.h
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2017 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  */
 #ifndef _KERNEL_VDSO_H

--- a/kernel/include/onyx/vector.h
+++ b/kernel/include/onyx/vector.h
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2019 Pedro Falcato
- * This file is part of Carbon, and is released under the terms of the MIT License
+ * This file is part of Carbon, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  */
 

--- a/kernel/include/onyx/vfork_completion.h
+++ b/kernel/include/onyx/vfork_completion.h
@@ -1,9 +1,9 @@
 /*
  * Copyright (c) 2024 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  *
- * SPDX-License-Identifier: MIT
+ * SPDX-License-Identifier: GPL-2.0-only
  */
 
 #ifndef _ONYX_VFORK_COMPLETION_H

--- a/kernel/include/onyx/vfs.h
+++ b/kernel/include/onyx/vfs.h
@@ -1,9 +1,9 @@
 /*
  * Copyright (c) 2016 - 2023 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  *
- * SPDX-License-Identifier: MIT
+ * SPDX-License-Identifier: GPL-2.0-only
  */
 
 #ifndef _ONYX_VFS_H

--- a/kernel/include/onyx/video.h
+++ b/kernel/include/onyx/video.h
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2017 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  */
 #ifndef _VIDEO_H

--- a/kernel/include/onyx/video/edid.h
+++ b/kernel/include/onyx/video/edid.h
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2018 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  */
 

--- a/kernel/include/onyx/vm.h
+++ b/kernel/include/onyx/vm.h
@@ -1,9 +1,9 @@
 /*
  * Copyright (c) 2016 - 2023 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  *
- * SPDX-License-Identifier: MIT
+ * SPDX-License-Identifier: GPL-2.0-only
  */
 #ifndef _ONYX_VM_H
 #define _ONYX_VM_H

--- a/kernel/include/onyx/vm_layout.h
+++ b/kernel/include/onyx/vm_layout.h
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2017 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  */
 

--- a/kernel/include/onyx/wait.h
+++ b/kernel/include/onyx/wait.h
@@ -1,9 +1,9 @@
 /*
  * Copyright (c) 2021 - 2022 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  *
- * SPDX-License-Identifier: MIT
+ * SPDX-License-Identifier: GPL-2.0-only
  */
 
 #ifndef _ONYX_WAIT_H

--- a/kernel/include/onyx/wait_queue.h
+++ b/kernel/include/onyx/wait_queue.h
@@ -1,9 +1,9 @@
 /*
  * Copyright (c) 2019 - 2023 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  *
- * SPDX-License-Identifier: MIT
+ * SPDX-License-Identifier: GPL-2.0-only
  */
 
 #ifndef _ONYX_WAIT_QUEUE_H

--- a/kernel/include/onyx/worker.h
+++ b/kernel/include/onyx/worker.h
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2017 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  */
 #ifndef _KERNEL_WORKER_H

--- a/kernel/include/onyx/x86/alternatives.h
+++ b/kernel/include/onyx/x86/alternatives.h
@@ -1,9 +1,9 @@
 /*
  * Copyright (c) 2021 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  *
- * SPDX-License-Identifier: MIT
+ * SPDX-License-Identifier: GPL-2.0-only
  */
 
 #ifndef _ONYX_X86_ALTERNATIVES_H

--- a/kernel/include/onyx/x86/apic.h
+++ b/kernel/include/onyx/x86/apic.h
@@ -1,9 +1,9 @@
 /*
  * Copyright (c) 2016 - 2023 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  *
- * SPDX-License-Identifier: MIT
+ * SPDX-License-Identifier: GPL-2.0-only
  */
 #ifndef _ONYX_X86_APIC_H
 #define _ONYX_X86_APIC_H

--- a/kernel/include/onyx/x86/asm.h
+++ b/kernel/include/onyx/x86/asm.h
@@ -1,9 +1,9 @@
 /*
  * Copyright (c) 2022 - 2023 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  *
- * SPDX-License-Identifier: MIT
+ * SPDX-License-Identifier: GPL-2.0-only
  */
 #ifndef _ONYX_X86_ASM_H
 #define _ONYX_X86_ASM_H
@@ -14,7 +14,7 @@
 
 #ifdef CONFIG_X86_RETHUNK
 #define RET jmp __x86_return_thunk
-#elif defined(CONFIG_X86_MITIGATE_SLS)
+#elif defined(CONFIG_X86_GPLv2IGATE_SLS)
 #define RET ret; int3
 #else
 #define RET ret

--- a/kernel/include/onyx/x86/avx.h
+++ b/kernel/include/onyx/x86/avx.h
@@ -1,9 +1,9 @@
 /*
  * Copyright (c) 2017 - 2021 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  *
- * SPDX-License-Identifier: MIT
+ * SPDX-License-Identifier: GPL-2.0-only
  */
 #ifndef _ONYX_X86_AVX_H
 #define _ONYX_X86_AVX_H

--- a/kernel/include/onyx/x86/control_regs.h
+++ b/kernel/include/onyx/x86/control_regs.h
@@ -1,9 +1,9 @@
 /*
  * Copyright (c) 2019 - 2021 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  *
- * SPDX-License-Identifier: MIT
+ * SPDX-License-Identifier: GPL-2.0-only
  */
 
 #ifndef _ONYX_X86_CONTROL_REGS_H

--- a/kernel/include/onyx/x86/eflags.h
+++ b/kernel/include/onyx/x86/eflags.h
@@ -1,9 +1,9 @@
 /*
  * Copyright (c) 2019 - 2021 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  *
- * SPDX-License-Identifier: MIT
+ * SPDX-License-Identifier: GPL-2.0-only
  */
 #ifndef _CARBON_X86_EFLAGS_H
 #define _CARBON_X86_EFLAGS_H

--- a/kernel/include/onyx/x86/gdt.h
+++ b/kernel/include/onyx/x86/gdt.h
@@ -1,9 +1,9 @@
 /*
  * Copyright (c) 2017 - 2021 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  *
- * SPDX-License-Identifier: MIT
+ * SPDX-License-Identifier: GPL-2.0-only
  */
 #ifndef _ONYX_X86_GDT_H
 #define _ONYX_X86_GDT_H

--- a/kernel/include/onyx/x86/idt.h
+++ b/kernel/include/onyx/x86/idt.h
@@ -1,9 +1,9 @@
 /*
  * Copyright (c) 2016 - 2021 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  *
- * SPDX-License-Identifier: MIT
+ * SPDX-License-Identifier: GPL-2.0-only
  */
 #ifndef _ONYX_X86_IDT_H
 #define _ONYX_X86_IDT_H

--- a/kernel/include/onyx/x86/include/platform/atomic.h
+++ b/kernel/include/onyx/x86/include/platform/atomic.h
@@ -1,9 +1,9 @@
 /*
  * Copyright (c) 2024 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  *
- * SPDX-License-Identifier: MIT
+ * SPDX-License-Identifier: GPL-2.0-only
  */
 
 #define smp_wmb() __asm__ __volatile__("" ::: "memory")

--- a/kernel/include/onyx/x86/include/platform/elf.h
+++ b/kernel/include/onyx/x86/include/platform/elf.h
@@ -1,9 +1,9 @@
 /*
  * Copyright (c) 2022 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  *
- * SPDX-License-Identifier: MIT
+ * SPDX-License-Identifier: GPL-2.0-only
  */
 #ifndef ONYX_X86_INCLUDE_PLATFORM_ELF_H
 #define ONYX_X86_INCLUDE_PLATFORM_ELF_H

--- a/kernel/include/onyx/x86/include/platform/internal_abi.h
+++ b/kernel/include/onyx/x86/include/platform/internal_abi.h
@@ -1,9 +1,9 @@
 /*
  * Copyright (c) 2021 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  *
- * SPDX-License-Identifier: MIT
+ * SPDX-License-Identifier: GPL-2.0-only
  */
 #ifndef _ONYX_X86_PLATFORM_INTERNAL_ABI_H
 #define _ONYX_X86_PLATFORM_INTERNAL_ABI_H

--- a/kernel/include/onyx/x86/include/platform/irq.h
+++ b/kernel/include/onyx/x86/include/platform/irq.h
@@ -1,9 +1,9 @@
 /*
  * Copyright (c) 2018 - 2021 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  *
- * SPDX-License-Identifier: MIT
+ * SPDX-License-Identifier: GPL-2.0-only
  */
 
 #ifndef _X86_IRQ_H

--- a/kernel/include/onyx/x86/include/platform/jump_label.h
+++ b/kernel/include/onyx/x86/include/platform/jump_label.h
@@ -1,9 +1,9 @@
 /*
  * Copyright (c) 2023 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  *
- * SPDX-License-Identifier: MIT
+ * SPDX-License-Identifier: GPL-2.0-only
  */
 #ifndef _ONYX_X86_PLATFORM_JUMP_LABEL_H
 #define _ONYX_X86_PLATFORM_JUMP_LABEL_H

--- a/kernel/include/onyx/x86/include/platform/kasan.h
+++ b/kernel/include/onyx/x86/include/platform/kasan.h
@@ -1,9 +1,9 @@
 /*
  * Copyright (c) 2023 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  *
- * SPDX-License-Identifier: MIT
+ * SPDX-License-Identifier: GPL-2.0-only
  */
 
 #ifndef _ONYX_X86_PLATFORM_KASAN_H

--- a/kernel/include/onyx/x86/include/platform/page.h
+++ b/kernel/include/onyx/x86/include/platform/page.h
@@ -1,9 +1,9 @@
 /*
  * Copyright (c) 2017 - 2021 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  *
- * SPDX-License-Identifier: MIT
+ * SPDX-License-Identifier: GPL-2.0-only
  */
 
 #ifndef _ONYX_X86_PAGE_H

--- a/kernel/include/onyx/x86/include/platform/syscall.h
+++ b/kernel/include/onyx/x86/include/platform/syscall.h
@@ -1,9 +1,9 @@
 /*
  * Copyright (c) 2018 - 2021 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  *
- * SPDX-License-Identifier: MIT
+ * SPDX-License-Identifier: GPL-2.0-only
  */
 
 #ifndef _ONYX_X86_SYSCALL_H

--- a/kernel/include/onyx/x86/include/platform/vm.h
+++ b/kernel/include/onyx/x86/include/platform/vm.h
@@ -1,9 +1,9 @@
 /*
  * Copyright (c) 2020 - 2023 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  *
- * SPDX-License-Identifier: MIT
+ * SPDX-License-Identifier: GPL-2.0-only
  */
 
 #ifndef _ONYX_X86_VM_H

--- a/kernel/include/onyx/x86/include/platform/vm_layout.h
+++ b/kernel/include/onyx/x86/include/platform/vm_layout.h
@@ -1,9 +1,9 @@
 /*
  * Copyright (c) 2017 - 2023 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  *
- * SPDX-License-Identifier: MIT
+ * SPDX-License-Identifier: GPL-2.0-only
  */
 
 #ifndef _X86_VM_H

--- a/kernel/include/onyx/x86/intrinsics.h
+++ b/kernel/include/onyx/x86/intrinsics.h
@@ -1,9 +1,9 @@
 /*
  * Copyright (c) 2021 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  *
- * SPDX-License-Identifier: MIT
+ * SPDX-License-Identifier: GPL-2.0-only
  */
 
 #ifndef _ONYX_X86_INTRINSICS_H

--- a/kernel/include/onyx/x86/isr.h
+++ b/kernel/include/onyx/x86/isr.h
@@ -1,9 +1,9 @@
 /*
  * Copyright (c) 2016 - 2021 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  *
- * SPDX-License-Identifier: MIT
+ * SPDX-License-Identifier: GPL-2.0-only
  */
 #ifndef _ONYX_X86_ISR_H
 #define _ONYX_X86_ISR_H

--- a/kernel/include/onyx/x86/ktrace.h
+++ b/kernel/include/onyx/x86/ktrace.h
@@ -1,9 +1,9 @@
 /*
  * Copyright (c) 2020 - 2021 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  *
- * SPDX-License-Identifier: MIT
+ * SPDX-License-Identifier: GPL-2.0-only
  */
 #ifndef _ONYX_X86_KTRACE_H
 #define _ONYX_X86_KTRACE_H

--- a/kernel/include/onyx/x86/kvm.h
+++ b/kernel/include/onyx/x86/kvm.h
@@ -1,9 +1,9 @@
 /*
  * Copyright (c) 2019 - 2021 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  *
- * SPDX-License-Identifier: MIT
+ * SPDX-License-Identifier: GPL-2.0-only
  */
 #ifndef _ONYX_X86_KVM_H
 #define _ONYX_X86_KVM_H

--- a/kernel/include/onyx/x86/mce.h
+++ b/kernel/include/onyx/x86/mce.h
@@ -1,9 +1,9 @@
 /*
  * Copyright (c) 2017 - 2021 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  *
- * SPDX-License-Identifier: MIT
+ * SPDX-License-Identifier: GPL-2.0-only
  */
 
 #ifndef _ONYX_X86_MCE_H

--- a/kernel/include/onyx/x86/msr.h
+++ b/kernel/include/onyx/x86/msr.h
@@ -1,9 +1,9 @@
 /*
  * Copyright (c) 2017 - 2021 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  *
- * SPDX-License-Identifier: MIT
+ * SPDX-License-Identifier: GPL-2.0-only
  */
 
 #ifndef _ONYX_X86_MSR_H

--- a/kernel/include/onyx/x86/pat.h
+++ b/kernel/include/onyx/x86/pat.h
@@ -1,9 +1,9 @@
 /*
  * Copyright (c) 2018 - 2021 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  *
- * SPDX-License-Identifier: MIT
+ * SPDX-License-Identifier: GPL-2.0-only
  */
 
 #ifndef _ONYX_X86_PAT_H

--- a/kernel/include/onyx/x86/percpu.h
+++ b/kernel/include/onyx/x86/percpu.h
@@ -1,9 +1,9 @@
 /*
  * Copyright (c) 2021 - 2024 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  *
- * SPDX-License-Identifier: MIT
+ * SPDX-License-Identifier: GPL-2.0-only
  */
 
 #ifndef _ONYX_X86_PERCPU_H

--- a/kernel/include/onyx/x86/pic.h
+++ b/kernel/include/onyx/x86/pic.h
@@ -1,9 +1,9 @@
 /*
  * Copyright (c) 2016 - 2021 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  *
- * SPDX-License-Identifier: MIT
+ * SPDX-License-Identifier: GPL-2.0-only
  */
 #ifndef _ONYX_X86_PIC_H
 #define _ONYX_X86_PIC_H

--- a/kernel/include/onyx/x86/pit.h
+++ b/kernel/include/onyx/x86/pit.h
@@ -1,9 +1,9 @@
 /*
  * Copyright (c) 2016 - 2021 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  *
- * SPDX-License-Identifier: MIT
+ * SPDX-License-Identifier: GPL-2.0-only
  */
 #ifndef _PIT_H
 #define _PIT_H

--- a/kernel/include/onyx/x86/platform_info.h
+++ b/kernel/include/onyx/x86/platform_info.h
@@ -1,9 +1,9 @@
 /*
  * Copyright (c) 2018 - 2021 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  *
- * SPDX-License-Identifier: MIT
+ * SPDX-License-Identifier: GPL-2.0-only
  */
 
 #ifndef _ONYX_X86_PLATFORM_INFO_H

--- a/kernel/include/onyx/x86/port_io.h
+++ b/kernel/include/onyx/x86/port_io.h
@@ -1,9 +1,9 @@
 /*
  * Copyright (c) 2016 - 2021 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  *
- * SPDX-License-Identifier: MIT
+ * SPDX-License-Identifier: GPL-2.0-only
  */
 #ifndef _ONYX_X86_PORT_IO_H
 #define _ONYX_X86_PORT_IO_H

--- a/kernel/include/onyx/x86/segments.h
+++ b/kernel/include/onyx/x86/segments.h
@@ -1,9 +1,9 @@
 /*
  * Copyright (c) 2019 - 2021 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  *
- * SPDX-License-Identifier: MIT
+ * SPDX-License-Identifier: GPL-2.0-only
  */
 
 #ifndef _X86_SEGMENTS_H

--- a/kernel/include/onyx/x86/signal.h
+++ b/kernel/include/onyx/x86/signal.h
@@ -1,9 +1,9 @@
 /*
  * Copyright (c) 2019 - 2021 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  *
- * SPDX-License-Identifier: MIT
+ * SPDX-License-Identifier: GPL-2.0-only
  */
 
 #ifndef _ONYX_X86_SIGNAL_H

--- a/kernel/include/onyx/x86/tsc.h
+++ b/kernel/include/onyx/x86/tsc.h
@@ -1,9 +1,9 @@
 /*
  * Copyright (c) 2017 - 2021 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  *
- * SPDX-License-Identifier: MIT
+ * SPDX-License-Identifier: GPL-2.0-only
  */
 
 #ifndef _ONYX_X86_TSC_H

--- a/kernel/include/onyx/yield.h
+++ b/kernel/include/onyx/yield.h
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2016, 2017 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  */
 #ifndef _YIELD_H

--- a/kernel/include/pci/pci-msi.h
+++ b/kernel/include/pci/pci-msi.h
@@ -1,9 +1,9 @@
 /*
  * Copyright (c) 2017 - 2021 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  *
- * SPDX-License-Identifier: MIT
+ * SPDX-License-Identifier: GPL-2.0-only
  */
 
 #ifndef _ONYX_PCI_MSI_H

--- a/kernel/include/pci/pci.h
+++ b/kernel/include/pci/pci.h
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2016, 2017 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  */
 #ifndef _KERNEL_PCI_H

--- a/kernel/include/pci/pcie.h
+++ b/kernel/include/pci/pcie.h
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2017 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  */
 #ifndef _PCIE_H

--- a/kernel/include/photon/photon-types.h
+++ b/kernel/include/photon/photon-types.h
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2017, 2018 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  */
 #ifndef _PHOTON_PHOTON_TYPES_H

--- a/kernel/include/proc_event.h
+++ b/kernel/include/proc_event.h
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2017 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  */
 

--- a/kernel/kernel/binfmt.cpp
+++ b/kernel/kernel/binfmt.cpp
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2017 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  */
 

--- a/kernel/kernel/binfmt/elf.cpp
+++ b/kernel/kernel/binfmt/elf.cpp
@@ -1,9 +1,9 @@
 /*
  * Copyright (c) 2017 - 2022 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  *
- * SPDX-License-Identifier: MIT
+ * SPDX-License-Identifier: GPL-2.0-only
  */
 
 #include <errno.h>

--- a/kernel/kernel/binfmt/elf_compat.cpp
+++ b/kernel/kernel/binfmt/elf_compat.cpp
@@ -1,9 +1,9 @@
 /*
  * Copyright (c) 2022 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  *
- * SPDX-License-Identifier: MIT
+ * SPDX-License-Identifier: GPL-2.0-only
  */
 
 #define ELF_COMPAT 1

--- a/kernel/kernel/binfmt/exec.cpp
+++ b/kernel/kernel/binfmt/exec.cpp
@@ -1,9 +1,9 @@
 /*
  * Copyright (c) 2020 - 2024 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  *
- * SPDX-License-Identifier: MIT
+ * SPDX-License-Identifier: GPL-2.0-only
  */
 
 #include <errno.h>

--- a/kernel/kernel/binfmt/module_loader.cpp
+++ b/kernel/kernel/binfmt/module_loader.cpp
@@ -1,9 +1,9 @@
 /*
  * Copyright (c) 2016 - 2022 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  *
- * SPDX-License-Identifier: MIT
+ * SPDX-License-Identifier: GPL-2.0-only
  */
 #include <assert.h>
 #include <errno.h>

--- a/kernel/kernel/binfmt/shebang.cpp
+++ b/kernel/kernel/binfmt/shebang.cpp
@@ -1,9 +1,9 @@
 /*
  * Copyright (c) 2020 - 2023 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  *
- * SPDX-License-Identifier: MIT
+ * SPDX-License-Identifier: GPL-2.0-only
  */
 
 #include <errno.h>

--- a/kernel/kernel/cmdline.cpp
+++ b/kernel/kernel/cmdline.cpp
@@ -1,9 +1,9 @@
 /*
  * Copyright (c) 2021 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  *
- * SPDX-License-Identifier: MIT
+ * SPDX-License-Identifier: GPL-2.0-only
  */
 
 #include <string.h>

--- a/kernel/kernel/compression.cpp
+++ b/kernel/kernel/compression.cpp
@@ -1,9 +1,9 @@
 /*
  * Copyright (c) 2022 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  *
- * SPDX-License-Identifier: MIT
+ * SPDX-License-Identifier: GPL-2.0-only
  */
 #include <errno.h>
 

--- a/kernel/kernel/copy.cpp
+++ b/kernel/kernel/copy.cpp
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2018 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  */
 #include <string.h>

--- a/kernel/kernel/cppnew.cpp
+++ b/kernel/kernel/cppnew.cpp
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2017 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  */
 /********************************************************************************

--- a/kernel/kernel/cpprt.cpp
+++ b/kernel/kernel/cpprt.cpp
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2017 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  */
 /********************************************************************************
@@ -19,7 +19,8 @@
 #include <onyx/mutex.h>
 #include <onyx/panic.h>
 
-extern "C" {
+extern "C"
+{
 
 /* Gets called when a virtual function isn't found */
 USED_FUNC

--- a/kernel/kernel/cputime.cpp
+++ b/kernel/kernel/cputime.cpp
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2020 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  */
 

--- a/kernel/kernel/crc32.cpp
+++ b/kernel/kernel/crc32.cpp
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2016, 2017 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  */
 #include <onyx/crc32.h>

--- a/kernel/kernel/cred.cpp
+++ b/kernel/kernel/cred.cpp
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2020, 2021 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  */
 #include <errno.h>

--- a/kernel/kernel/ctor.cpp
+++ b/kernel/kernel/ctor.cpp
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2021 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  */
 

--- a/kernel/kernel/dev.cpp
+++ b/kernel/kernel/dev.cpp
@@ -1,9 +1,9 @@
 /*
  * Copyright (c) 2017 - 2022 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  *
- * SPDX-License-Identifier: MIT
+ * SPDX-License-Identifier: GPL-2.0-only
  */
 #include <assert.h>
 #include <stdbool.h>

--- a/kernel/kernel/dma.cpp
+++ b/kernel/kernel/dma.cpp
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2018 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  */
 #include <stdbool.h>

--- a/kernel/kernel/dpc.cpp
+++ b/kernel/kernel/dpc.cpp
@@ -1,9 +1,9 @@
 /*
  * Copyright (c) 2017 - 2022 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  *
- * SPDX-License-Identifier: MIT
+ * SPDX-License-Identifier: GPL-2.0-only
  */
 #include <assert.h>
 #include <stdio.h>

--- a/kernel/kernel/driver.cpp
+++ b/kernel/kernel/driver.cpp
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2017 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  */
 #include <stdint.h>

--- a/kernel/kernel/exceptions.cpp
+++ b/kernel/kernel/exceptions.cpp
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2019 Pedro Falcato
- * This file is part of Carbon, and is released under the terms of the MIT License
+ * This file is part of Carbon, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  */
 

--- a/kernel/kernel/font.cpp
+++ b/kernel/kernel/font.cpp
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2018 Pedro Falcato
- * This file is part of Carbon, and is released under the terms of the MIT License
+ * This file is part of Carbon, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  */
 

--- a/kernel/kernel/framebuffer.cpp
+++ b/kernel/kernel/framebuffer.cpp
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2018 Pedro Falcato
- * This file is part of Carbon, and is released under the terms of the MIT License
+ * This file is part of Carbon, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  */
 #include <stddef.h>

--- a/kernel/kernel/fs/anon_inode.cpp
+++ b/kernel/kernel/fs/anon_inode.cpp
@@ -1,9 +1,9 @@
 /*
  * Copyright (c) 2023 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  *
- * SPDX-License-Identifier: MIT
+ * SPDX-License-Identifier: GPL-2.0-only
  */
 #include <onyx/assert.h>
 #include <onyx/cred.h>

--- a/kernel/kernel/fs/block.cpp
+++ b/kernel/kernel/fs/block.cpp
@@ -1,9 +1,9 @@
 /*
  * Copyright (c) 2016 - 2024 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  *
- * SPDX-License-Identifier: MIT
+ * SPDX-License-Identifier: GPL-2.0-only
  */
 #include <errno.h>
 #include <stddef.h>

--- a/kernel/kernel/fs/block/bio.cpp
+++ b/kernel/kernel/fs/block/bio.cpp
@@ -1,9 +1,9 @@
 /*
  * Copyright (c) 2024 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  *
- * SPDX-License-Identifier: MIT
+ * SPDX-License-Identifier: GPL-2.0-only
  */
 #include <onyx/bio.h>
 #include <onyx/block.h>

--- a/kernel/kernel/fs/block/bounce.c
+++ b/kernel/kernel/fs/block/bounce.c
@@ -1,9 +1,9 @@
 /*
  * Copyright (c) 2024 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  *
- * SPDX-License-Identifier: MIT
+ * SPDX-License-Identifier: GPL-2.0-only
  */
 #include <onyx/bio.h>
 

--- a/kernel/kernel/fs/block/io-queue.cpp
+++ b/kernel/kernel/fs/block/io-queue.cpp
@@ -1,9 +1,9 @@
 /*
  * Copyright (c) 2022 - 2024 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  *
- * SPDX-License-Identifier: MIT
+ * SPDX-License-Identifier: GPL-2.0-only
  */
 #include <onyx/block.h>
 #include <onyx/block/io-queue.h>

--- a/kernel/kernel/fs/block/multiqueue.cpp
+++ b/kernel/kernel/fs/block/multiqueue.cpp
@@ -1,9 +1,9 @@
 /*
  * Copyright (c) 2024 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  *
- * SPDX-License-Identifier: MIT
+ * SPDX-License-Identifier: GPL-2.0-only
  */
 #include <onyx/block.h>
 #include <onyx/block/blk_plug.h>

--- a/kernel/kernel/fs/block/request.cpp
+++ b/kernel/kernel/fs/block/request.cpp
@@ -1,9 +1,9 @@
 /*
  * Copyright (c) 2024 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  *
- * SPDX-License-Identifier: MIT
+ * SPDX-License-Identifier: GPL-2.0-only
  */
 #include <onyx/block.h>
 #include <onyx/block/blk_plug.h>

--- a/kernel/kernel/fs/buffer.cpp
+++ b/kernel/kernel/fs/buffer.cpp
@@ -1,9 +1,9 @@
 /*
  * Copyright (c) 2020 - 2024 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  *
- * SPDX-License-Identifier: MIT
+ * SPDX-License-Identifier: GPL-2.0-only
  */
 #include <errno.h>
 #include <stdio.h>

--- a/kernel/kernel/fs/dentry.cpp
+++ b/kernel/kernel/fs/dentry.cpp
@@ -1,9 +1,9 @@
 /*
  * Copyright (c) 2020 - 2024 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  *
- * SPDX-License-Identifier: MIT
+ * SPDX-License-Identifier: GPL-2.0-only
  */
 #include <assert.h>
 #include <errno.h>

--- a/kernel/kernel/fs/dev.cpp
+++ b/kernel/kernel/fs/dev.cpp
@@ -1,9 +1,9 @@
 /*
  * Copyright (c) 2016 - 2024 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  *
- * SPDX-License-Identifier: MIT
+ * SPDX-License-Identifier: GPL-2.0-only
  */
 
 #include <assert.h>

--- a/kernel/kernel/fs/ext2/alloc.cpp
+++ b/kernel/kernel/fs/ext2/alloc.cpp
@@ -1,9 +1,9 @@
 /*
  * Copyright (c) 2017 - 2022 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  *
- * SPDX-License-Identifier: MIT
+ * SPDX-License-Identifier: GPL-2.0-only
  */
 
 #include <assert.h>

--- a/kernel/kernel/fs/ext2/block_groups.cpp
+++ b/kernel/kernel/fs/ext2/block_groups.cpp
@@ -1,9 +1,9 @@
 /*
  * Copyright (c) 2017 - 2021 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  *
- * SPDX-License-Identifier: MIT
+ * SPDX-License-Identifier: GPL-2.0-only
  */
 
 #include <stdint.h>

--- a/kernel/kernel/fs/ext2/ext2.cpp
+++ b/kernel/kernel/fs/ext2/ext2.cpp
@@ -1,9 +1,9 @@
 /*
  * Copyright (c) 2016 - 2024 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  *
- * SPDX-License-Identifier: MIT
+ * SPDX-License-Identifier: GPL-2.0-only
  */
 
 #include "ext2.h"

--- a/kernel/kernel/fs/ext2/ext2.h
+++ b/kernel/kernel/fs/ext2/ext2.h
@@ -1,9 +1,9 @@
 /*
  * Copyright (c) 2016 - 2024 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  *
- * SPDX-License-Identifier: MIT
+ * SPDX-License-Identifier: GPL-2.0-only
  */
 #ifndef _EXT2_H
 #define _EXT2_H

--- a/kernel/kernel/fs/ext2/ext2_ll.cpp
+++ b/kernel/kernel/fs/ext2/ext2_ll.cpp
@@ -1,9 +1,9 @@
 /*
  * Copyright (c) 2017 - 2022 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  *
- * SPDX-License-Identifier: MIT
+ * SPDX-License-Identifier: GPL-2.0-only
  */
 #include <errno.h>
 #include <stdio.h>

--- a/kernel/kernel/fs/ext2/inode.cpp
+++ b/kernel/kernel/fs/ext2/inode.cpp
@@ -1,9 +1,9 @@
 /*
  * Copyright (c) 2017 - 2024 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  *
- * SPDX-License-Identifier: MIT
+ * SPDX-License-Identifier: GPL-2.0-only
  */
 
 #include <assert.h>

--- a/kernel/kernel/fs/ext2/symlink.cpp
+++ b/kernel/kernel/fs/ext2/symlink.cpp
@@ -1,9 +1,9 @@
 /*
  * Copyright (c) 2017 - 2021 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  *
- * SPDX-License-Identifier: MIT
+ * SPDX-License-Identifier: GPL-2.0-only
  */
 
 #include <errno.h>

--- a/kernel/kernel/fs/file.cpp
+++ b/kernel/kernel/fs/file.cpp
@@ -1,9 +1,9 @@
 /*
  * Copyright (c) 2017 - 2023 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  *
- * SPDX-License-Identifier: MIT
+ * SPDX-License-Identifier: GPL-2.0-only
  */
 
 #include <assert.h>

--- a/kernel/kernel/fs/filemap.cpp
+++ b/kernel/kernel/fs/filemap.cpp
@@ -1,9 +1,9 @@
 /*
  * Copyright (c) 2017 - 2024 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  *
- * SPDX-License-Identifier: MIT
+ * SPDX-License-Identifier: GPL-2.0-only
  */
 
 #include <onyx/block.h>

--- a/kernel/kernel/fs/flock.c
+++ b/kernel/kernel/fs/flock.c
@@ -1,9 +1,9 @@
 /*
  * Copyright (c) 2024 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  *
- * SPDX-License-Identifier: MIT
+ * SPDX-License-Identifier: GPL-2.0-only
  */
 #include <onyx/compiler.h>
 #include <onyx/file.h>

--- a/kernel/kernel/fs/inode.cpp
+++ b/kernel/kernel/fs/inode.cpp
@@ -1,9 +1,9 @@
 /*
  * Copyright (c) 2020 - 2024 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  *
- * SPDX-License-Identifier: MIT
+ * SPDX-License-Identifier: GPL-2.0-only
  */
 
 #include <errno.h>

--- a/kernel/kernel/fs/namei.cpp
+++ b/kernel/kernel/fs/namei.cpp
@@ -1,9 +1,9 @@
 /*
  * Copyright (c) 2020 - 2024 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  *
- * SPDX-License-Identifier: MIT
+ * SPDX-License-Identifier: GPL-2.0-only
  */
 #include <onyx/cred.h>
 #include <onyx/dentry.h>

--- a/kernel/kernel/fs/null.cpp
+++ b/kernel/kernel/fs/null.cpp
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2016, 2017 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  */
 #include <stdlib.h>

--- a/kernel/kernel/fs/partition.cpp
+++ b/kernel/kernel/fs/partition.cpp
@@ -1,9 +1,9 @@
 /*
  * Copyright (c) 2016 - 2024 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  *
- * SPDX-License-Identifier: MIT
+ * SPDX-License-Identifier: GPL-2.0-only
  */
 #include <errno.h>
 #include <stdbool.h>

--- a/kernel/kernel/fs/pipe.cpp
+++ b/kernel/kernel/fs/pipe.cpp
@@ -1,9 +1,9 @@
 /*
  * Copyright (c) 2017 - 2023 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  *
- * SPDX-License-Identifier: MIT
+ * SPDX-License-Identifier: GPL-2.0-only
  */
 
 #include <errno.h>

--- a/kernel/kernel/fs/poll.cpp
+++ b/kernel/kernel/fs/poll.cpp
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2019 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  */
 

--- a/kernel/kernel/fs/pseudo.cpp
+++ b/kernel/kernel/fs/pseudo.cpp
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2018 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  */
 

--- a/kernel/kernel/fs/readahead.c
+++ b/kernel/kernel/fs/readahead.c
@@ -1,9 +1,9 @@
 /*
  * Copyright (c) 2024 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  *
- * SPDX-License-Identifier: MIT
+ * SPDX-License-Identifier: GPL-2.0-only
  */
 
 #include <stdbool.h>

--- a/kernel/kernel/fs/superblock.cpp
+++ b/kernel/kernel/fs/superblock.cpp
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2017 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  */
 #include <onyx/block.h>

--- a/kernel/kernel/fs/sysfs.cpp
+++ b/kernel/kernel/fs/sysfs.cpp
@@ -1,9 +1,9 @@
 /*
  * Copyright (c) 2017 - 2022 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  *
- * SPDX-License-Identifier: MIT
+ * SPDX-License-Identifier: GPL-2.0-only
  */
 
 #include <assert.h>

--- a/kernel/kernel/fs/tmpfs.cpp
+++ b/kernel/kernel/fs/tmpfs.cpp
@@ -1,9 +1,9 @@
 /*
  * Copyright (c) 2016 - 2023 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  *
- * SPDX-License-Identifier: MIT
+ * SPDX-License-Identifier: GPL-2.0-only
  */
 
 #include <assert.h>

--- a/kernel/kernel/fs/vfs.cpp
+++ b/kernel/kernel/fs/vfs.cpp
@@ -1,9 +1,9 @@
 /*
  * Copyright (c) 2016 - 2023 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  *
- * SPDX-License-Identifier: MIT
+ * SPDX-License-Identifier: GPL-2.0-only
  */
 #include <assert.h>
 #include <errno.h>

--- a/kernel/kernel/fs/writeback.cpp
+++ b/kernel/kernel/fs/writeback.cpp
@@ -1,9 +1,9 @@
 /*
  * Copyright (c) 2019 - 2023 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  *
- * SPDX-License-Identifier: MIT
+ * SPDX-License-Identifier: GPL-2.0-only
  */
 #include <errno.h>
 #include <stdio.h>

--- a/kernel/kernel/fs/zero.cpp
+++ b/kernel/kernel/fs/zero.cpp
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2016-2020 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  */
 #include <errno.h>

--- a/kernel/kernel/futex.cpp
+++ b/kernel/kernel/futex.cpp
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2017 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  */
 #include <errno.h>

--- a/kernel/kernel/handle.cpp
+++ b/kernel/kernel/handle.cpp
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2021 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  */
 

--- a/kernel/kernel/i2c.cpp
+++ b/kernel/kernel/i2c.cpp
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2018 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  */
 #include <assert.h>

--- a/kernel/kernel/id_manager.cpp
+++ b/kernel/kernel/id_manager.cpp
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2017 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  */
 #include <assert.h>

--- a/kernel/kernel/init.cpp
+++ b/kernel/kernel/init.cpp
@@ -1,9 +1,9 @@
 /*
  * Copyright (c) 2016 - 2023 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  *
- * SPDX-License-Identifier: MIT
+ * SPDX-License-Identifier: GPL-2.0-only
  */
 
 /**************************************************************************

--- a/kernel/kernel/initrd.cpp
+++ b/kernel/kernel/initrd.cpp
@@ -1,9 +1,9 @@
 /*
  * Copyright (c) 2016 - 2024 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  *
- * SPDX-License-Identifier: MIT
+ * SPDX-License-Identifier: GPL-2.0-only
  */
 
 #include <assert.h>

--- a/kernel/kernel/input/device.cpp
+++ b/kernel/kernel/input/device.cpp
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2020 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  */
 #include <stdlib.h>
@@ -54,23 +54,23 @@ void input_device_submit_event(struct input_device *dev, struct input_event *ev)
 
     switch (ev->code)
     {
-    case KEYMAP_KEY_LSHIFT:
-    case KEYMAP_KEY_RSHIFT:
-        dev->state.shift_pressed = pressed;
-        break;
-    case KEYMAP_KEY_CAPS_LOCK:
-        dev->state.caps_enabled = !(dev->state.caps_enabled);
-        break;
-    case KEYMAP_KEY_LALT:
-    case KEYMAP_KEY_ALTGR:
-        dev->state.alt_pressed = pressed;
-        break;
-    case KEYMAP_KEY_LCTRL:
-    case KEYMAP_KEY_RCTRL:
-        dev->state.ctrl_pressed = pressed;
-        break;
-    default:
-        break;
+        case KEYMAP_KEY_LSHIFT:
+        case KEYMAP_KEY_RSHIFT:
+            dev->state.shift_pressed = pressed;
+            break;
+        case KEYMAP_KEY_CAPS_LOCK:
+            dev->state.caps_enabled = !(dev->state.caps_enabled);
+            break;
+        case KEYMAP_KEY_LALT:
+        case KEYMAP_KEY_ALTGR:
+            dev->state.alt_pressed = pressed;
+            break;
+        case KEYMAP_KEY_LCTRL:
+        case KEYMAP_KEY_RCTRL:
+            dev->state.ctrl_pressed = pressed;
+            break;
+        default:
+            break;
     }
 
     vterm_submit_event(dev, ev);

--- a/kernel/kernel/input/state.cpp
+++ b/kernel/kernel/input/state.cpp
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2020 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  */
 #include <onyx/input/state.h>

--- a/kernel/kernel/internal_abi.cpp
+++ b/kernel/kernel/internal_abi.cpp
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2021 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  */
 

--- a/kernel/kernel/iovec_iter.cpp
+++ b/kernel/kernel/iovec_iter.cpp
@@ -1,9 +1,9 @@
 /*
  * Copyright (c) 2023 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  *
- * SPDX-License-Identifier: MIT
+ * SPDX-License-Identifier: GPL-2.0-only
  */
 #include <string.h>
 

--- a/kernel/kernel/irq.cpp
+++ b/kernel/kernel/irq.cpp
@@ -1,9 +1,9 @@
 /*
  * Copyright (c) 2016 - 2023 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  *
- * SPDX-License-Identifier: MIT
+ * SPDX-License-Identifier: GPL-2.0-only
  */
 
 #include <assert.h>

--- a/kernel/kernel/jump_label.cpp
+++ b/kernel/kernel/jump_label.cpp
@@ -1,9 +1,9 @@
 /*
  * Copyright (c) 2023 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  *
- * SPDX-License-Identifier: MIT
+ * SPDX-License-Identifier: GPL-2.0-only
  */
 
 #include <onyx/code_patch.h>

--- a/kernel/kernel/kcov.cpp
+++ b/kernel/kernel/kcov.cpp
@@ -1,9 +1,9 @@
 /*
  * Copyright (c) 2023 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  *
- * SPDX-License-Identifier: MIT
+ * SPDX-License-Identifier: GPL-2.0-only
  */
 #include <onyx/dev.h>
 #include <onyx/init.h>

--- a/kernel/kernel/kernlog.cpp
+++ b/kernel/kernel/kernlog.cpp
@@ -1,9 +1,9 @@
 /*
  * Copyright (c) 2016 - 2024 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  *
- * SPDX-License-Identifier: MIT
+ * SPDX-License-Identifier: GPL-2.0-only
  */
 #include <errno.h>
 #include <stdarg.h>

--- a/kernel/kernel/ktest.cpp
+++ b/kernel/kernel/ktest.cpp
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2018 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  */
 

--- a/kernel/kernel/ktrace.cpp
+++ b/kernel/kernel/ktrace.cpp
@@ -1,9 +1,9 @@
 /*
  * Copyright (c) 2020 - 2023 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  *
- * SPDX-License-Identifier: MIT
+ * SPDX-License-Identifier: GPL-2.0-only
  */
 #include <errno.h>
 #include <stdio.h>

--- a/kernel/kernel/kunit.cpp
+++ b/kernel/kernel/kunit.cpp
@@ -1,9 +1,9 @@
 /*
  * Copyright (c) 2022 - 2024 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  *
- * SPDX-License-Identifier: MIT
+ * SPDX-License-Identifier: GPL-2.0-only
  */
 #define pr_fmt(fmt) "kunit: " fmt
 #include <onyx/init.h>

--- a/kernel/kernel/list.cpp
+++ b/kernel/kernel/list.cpp
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2020 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  */
 #include <assert.h>

--- a/kernel/kernel/memstream.cpp
+++ b/kernel/kernel/memstream.cpp
@@ -1,9 +1,9 @@
 /*
  * Copyright (c) 2022 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  *
- * SPDX-License-Identifier: MIT
+ * SPDX-License-Identifier: GPL-2.0-only
  */
 #include <onyx/memstream.h>
 #include <onyx/vfs.h>

--- a/kernel/kernel/mm/amap.cpp
+++ b/kernel/kernel/mm/amap.cpp
@@ -1,9 +1,9 @@
 /*
  * Copyright (c) 2023 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  *
- * SPDX-License-Identifier: MIT
+ * SPDX-License-Identifier: GPL-2.0-only
  */
 #include <onyx/mm/amap.h>
 #include <onyx/mm/slab.h>

--- a/kernel/kernel/mm/anon.cpp
+++ b/kernel/kernel/mm/anon.cpp
@@ -1,9 +1,9 @@
 /*
  * Copyright (c) 2023 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  *
- * SPDX-License-Identifier: MIT
+ * SPDX-License-Identifier: GPL-2.0-only
  */
 
 #include <onyx/dentry.h>

--- a/kernel/kernel/mm/asan/asan.cpp
+++ b/kernel/kernel/mm/asan/asan.cpp
@@ -1,9 +1,9 @@
 /*
  * Copyright (c) 2019 - 2023 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  *
- * SPDX-License-Identifier: MIT
+ * SPDX-License-Identifier: GPL-2.0-only
  */
 
 #include <assert.h>

--- a/kernel/kernel/mm/asan/quarantine.cpp
+++ b/kernel/kernel/mm/asan/quarantine.cpp
@@ -1,9 +1,9 @@
 /*
  * Copyright (c) 2022 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  *
- * SPDX-License-Identifier: MIT
+ * SPDX-License-Identifier: GPL-2.0-only
  */
 
 #include <stddef.h>

--- a/kernel/kernel/mm/bootmem.cpp
+++ b/kernel/kernel/mm/bootmem.cpp
@@ -1,9 +1,9 @@
 /*
  * Copyright (c) 2016 - 2024 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  *
- * SPDX-License-Identifier: MIT
+ * SPDX-License-Identifier: GPL-2.0-only
  */
 
 #include <stdbool.h>

--- a/kernel/kernel/mm/mincore.cpp
+++ b/kernel/kernel/mm/mincore.cpp
@@ -1,9 +1,9 @@
 /*
  * Copyright (c) 2024 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  *
- * SPDX-License-Identifier: MIT
+ * SPDX-License-Identifier: GPL-2.0-only
  */
 
 #include <onyx/process.h>

--- a/kernel/kernel/mm/page.cpp
+++ b/kernel/kernel/mm/page.cpp
@@ -1,9 +1,9 @@
 /*
  * Copyright (c) 2017 - 2023 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  *
- * SPDX-License-Identifier: MIT
+ * SPDX-License-Identifier: GPL-2.0-only
  */
 
 #include <assert.h>

--- a/kernel/kernel/mm/page_lru.c
+++ b/kernel/kernel/mm/page_lru.c
@@ -1,9 +1,9 @@
 /*
  * Copyright (c) 2024 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  *
- * SPDX-License-Identifier: MIT
+ * SPDX-License-Identifier: GPL-2.0-only
  */
 #include <onyx/mm/page_lru.h>
 #include <onyx/page.h>

--- a/kernel/kernel/mm/page_owner.cpp
+++ b/kernel/kernel/mm/page_owner.cpp
@@ -1,9 +1,9 @@
 /*
  * Copyright (c) 2024 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  *
- * SPDX-License-Identifier: MIT
+ * SPDX-License-Identifier: GPL-2.0-only
  */
 #include <onyx/page.h>
 #include <onyx/perf_probe.h>

--- a/kernel/kernel/mm/pagealloc.cpp
+++ b/kernel/kernel/mm/pagealloc.cpp
@@ -1,9 +1,9 @@
 /*
  * Copyright (c) 2017 - 2024 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  *
- * SPDX-License-Identifier: MIT
+ * SPDX-License-Identifier: GPL-2.0-only
  */
 
 #include <assert.h>

--- a/kernel/kernel/mm/reclaim.c
+++ b/kernel/kernel/mm/reclaim.c
@@ -1,9 +1,9 @@
 /*
  * Copyright (c) 2023 - 2024 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  *
- * SPDX-License-Identifier: MIT
+ * SPDX-License-Identifier: GPL-2.0-only
  */
 #include <stdio.h>
 

--- a/kernel/kernel/mm/slab.cpp
+++ b/kernel/kernel/mm/slab.cpp
@@ -1,9 +1,9 @@
 /*
  * Copyright (c) 2022 - 2024 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  *
- * SPDX-License-Identifier: MIT
+ * SPDX-License-Identifier: GPL-2.0-only
  */
 
 #include <onyx/cpu.h>

--- a/kernel/kernel/mm/vm.cpp
+++ b/kernel/kernel/mm/vm.cpp
@@ -1,9 +1,9 @@
 /*
  * Copyright (c) 2016 - 2023 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  *
- * SPDX-License-Identifier: MIT
+ * SPDX-License-Identifier: GPL-2.0-only
  */
 
 #include <assert.h>

--- a/kernel/kernel/mm/vm_object.cpp
+++ b/kernel/kernel/mm/vm_object.cpp
@@ -1,9 +1,9 @@
 /*
  * Copyright (c) 2018 - 2024 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  *
- * SPDX-License-Identifier: MIT
+ * SPDX-License-Identifier: GPL-2.0-only
  */
 #include <assert.h>
 #include <stdio.h>

--- a/kernel/kernel/mm/vm_tests.cpp
+++ b/kernel/kernel/mm/vm_tests.cpp
@@ -1,9 +1,9 @@
 /*
  * Copyright (c) 2023 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  *
- * SPDX-License-Identifier: MIT
+ * SPDX-License-Identifier: GPL-2.0-only
  */
 
 #include <onyx/kunit.h>

--- a/kernel/kernel/mm/vmalloc.cpp
+++ b/kernel/kernel/mm/vmalloc.cpp
@@ -1,9 +1,9 @@
 /*
  * Copyright (c) 2022 - 2023 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  *
- * SPDX-License-Identifier: MIT
+ * SPDX-License-Identifier: GPL-2.0-only
  */
 
 #include <lib/binary_search_tree.h>

--- a/kernel/kernel/modules.cpp
+++ b/kernel/kernel/modules.cpp
@@ -1,9 +1,9 @@
 /*
  * Copyright (c) 2016 - 2023 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  *
- * SPDX-License-Identifier: MIT
+ * SPDX-License-Identifier: GPL-2.0-only
  */
 #include <errno.h>
 #include <stdbool.h>

--- a/kernel/kernel/net/checksum.cpp
+++ b/kernel/kernel/net/checksum.cpp
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2020 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  */
 

--- a/kernel/kernel/net/ethernet.cpp
+++ b/kernel/kernel/net/ethernet.cpp
@@ -1,9 +1,9 @@
 /*
  * Copyright (c) 2016 - 2022 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  *
- * SPDX-License-Identifier: MIT
+ * SPDX-License-Identifier: GPL-2.0-only
  */
 
 #include <errno.h>

--- a/kernel/kernel/net/hostname.cpp
+++ b/kernel/kernel/net/hostname.cpp
@@ -1,16 +1,16 @@
 /*
  * Copyright (c) 2016, 2017 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  */
 #include <errno.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include <onyx/types.h>
 #include <sys/utsname.h>
 
 #include <onyx/net/network.h>
+#include <onyx/types.h>
 #include <onyx/vm.h>
 
 /* FIXME: 98% sure there's a race condition here, TOFIX */

--- a/kernel/kernel/net/inet.cpp
+++ b/kernel/kernel/net/inet.cpp
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2020 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  */
 

--- a/kernel/kernel/net/inet_cork.cpp
+++ b/kernel/kernel/net/inet_cork.cpp
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2020 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  */
 #include <onyx/net/inet_cork.h>

--- a/kernel/kernel/net/ipv4/arp.cpp
+++ b/kernel/kernel/net/ipv4/arp.cpp
@@ -1,9 +1,9 @@
 /*
  * Copyright (c) 2016 - 2022 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  *
- * SPDX-License-Identifier: MIT
+ * SPDX-License-Identifier: GPL-2.0-only
  */
 #include <errno.h>
 #include <stdlib.h>

--- a/kernel/kernel/net/ipv4/icmp.cpp
+++ b/kernel/kernel/net/ipv4/icmp.cpp
@@ -1,9 +1,9 @@
 /*
  * Copyright (c) 2016 - 2022 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  *
- * SPDX-License-Identifier: MIT
+ * SPDX-License-Identifier: GPL-2.0-only
  */
 
 #include <errno.h>

--- a/kernel/kernel/net/ipv4/ipv4.cpp
+++ b/kernel/kernel/net/ipv4/ipv4.cpp
@@ -1,9 +1,9 @@
 /*
  * Copyright (c) 2016 - 2022 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  *
- * SPDX-License-Identifier: MIT
+ * SPDX-License-Identifier: GPL-2.0-only
  */
 #include <errno.h>
 #include <stdint.h>

--- a/kernel/kernel/net/ipv4/ipv4_netkernel.cpp
+++ b/kernel/kernel/net/ipv4/ipv4_netkernel.cpp
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2020 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  */
 

--- a/kernel/kernel/net/ipv6/icmpv6.cpp
+++ b/kernel/kernel/net/ipv6/icmpv6.cpp
@@ -1,9 +1,9 @@
 /*
  * Copyright (c) 2020 - 2022 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  *
- * SPDX-License-Identifier: MIT
+ * SPDX-License-Identifier: GPL-2.0-only
  */
 #include <errno.h>
 

--- a/kernel/kernel/net/ipv6/ipv6.cpp
+++ b/kernel/kernel/net/ipv6/ipv6.cpp
@@ -1,9 +1,9 @@
 /*
  * Copyright (c) 2020 - 2022 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  *
- * SPDX-License-Identifier: MIT
+ * SPDX-License-Identifier: GPL-2.0-only
  */
 
 #include <onyx/net/icmpv6.h>

--- a/kernel/kernel/net/ipv6/ipv6_netkernel.cpp
+++ b/kernel/kernel/net/ipv6/ipv6_netkernel.cpp
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2020 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  */
 

--- a/kernel/kernel/net/ipv6/ndp.cpp
+++ b/kernel/kernel/net/ipv6/ndp.cpp
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2020 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  */
 #include <errno.h>
@@ -77,11 +77,11 @@ int ndp_handle_na(netif *netif, packetbuf *buf)
 
         switch (hdr->type)
         {
-        case ND_OPT_TARGET_LINKADDR: {
-            if (length != 8)
-                return -EINVAL;
-            target = (const unsigned char *) optptr + 2;
-        }
+            case ND_OPT_TARGET_LINKADDR: {
+                if (length != 8)
+                    return -EINVAL;
+                target = (const unsigned char *) optptr + 2;
+            }
         }
 
         optptr += length;

--- a/kernel/kernel/net/loopback.cpp
+++ b/kernel/kernel/net/loopback.cpp
@@ -1,9 +1,9 @@
 /*
  * Copyright (c) 2020 - 2022 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  *
- * SPDX-License-Identifier: MIT
+ * SPDX-License-Identifier: GPL-2.0-only
  */
 #include <stdio.h>
 

--- a/kernel/kernel/net/neighbour.cpp
+++ b/kernel/kernel/net/neighbour.cpp
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2020 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  */
 #include <onyx/net/neighbour.h>

--- a/kernel/kernel/net/netif.cpp
+++ b/kernel/kernel/net/netif.cpp
@@ -1,9 +1,9 @@
 /*
  * Copyright (c) 2017 - 2022 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  *
- * SPDX-License-Identifier: MIT
+ * SPDX-License-Identifier: GPL-2.0-only
  */
 #include <assert.h>
 #include <errno.h>

--- a/kernel/kernel/net/netkernel.cpp
+++ b/kernel/kernel/net/netkernel.cpp
@@ -1,9 +1,9 @@
 /*
  * Copyright (c) 2020 - 2022 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  *
- * SPDX-License-Identifier: MIT
+ * SPDX-License-Identifier: GPL-2.0-only
  */
 
 #include <onyx/init.h>

--- a/kernel/kernel/net/network.cpp
+++ b/kernel/kernel/net/network.cpp
@@ -1,11 +1,10 @@
 /*
  * Copyright (c) 2016, 2017 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  */
 #include <assert.h>
 #include <errno.h>
-#include <uapi/fcntl.h>
 #include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -22,6 +21,8 @@
 #include <onyx/net/network.h>
 #include <onyx/net/udp.h>
 #include <onyx/packetbuf.h>
+
+#include <uapi/fcntl.h>
 
 #include <onyx/mm/pool.hpp>
 

--- a/kernel/kernel/net/packetbuf.cpp
+++ b/kernel/kernel/net/packetbuf.cpp
@@ -1,9 +1,9 @@
 /*
  * Copyright (c) 2020 - 2023 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  *
- * SPDX-License-Identifier: MIT
+ * SPDX-License-Identifier: GPL-2.0-only
  */
 
 #include <errno.h>

--- a/kernel/kernel/net/socket.cpp
+++ b/kernel/kernel/net/socket.cpp
@@ -1,9 +1,9 @@
 /*
  * Copyright (c) 2018 - 2022 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  *
- * SPDX-License-Identifier: MIT
+ * SPDX-License-Identifier: GPL-2.0-only
  */
 #include <errno.h>
 #include <net/if.h>

--- a/kernel/kernel/net/socket_table.cpp
+++ b/kernel/kernel/net/socket_table.cpp
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2020 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  */
 #include <onyx/net/inet_socket.h>

--- a/kernel/kernel/net/tcp.cpp
+++ b/kernel/kernel/net/tcp.cpp
@@ -1,9 +1,9 @@
 /*
  * Copyright (c) 2020 - 2022 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  *
- * SPDX-License-Identifier: MIT
+ * SPDX-License-Identifier: GPL-2.0-only
  */
 
 #include <errno.h>

--- a/kernel/kernel/net/udp.cpp
+++ b/kernel/kernel/net/udp.cpp
@@ -1,9 +1,9 @@
 /*
  * Copyright (c) 2016 - 2022 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  *
- * SPDX-License-Identifier: MIT
+ * SPDX-License-Identifier: GPL-2.0-only
  */
 #include <assert.h>
 #include <endian.h>

--- a/kernel/kernel/net/unix.cpp
+++ b/kernel/kernel/net/unix.cpp
@@ -1,9 +1,9 @@
 /*
  * Copyright (c) 2022 - 2023 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  *
- * SPDX-License-Identifier: MIT
+ * SPDX-License-Identifier: GPL-2.0-only
  */
 
 #include <sys/un.h>

--- a/kernel/kernel/object.cpp
+++ b/kernel/kernel/object.cpp
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2018 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  */
 

--- a/kernel/kernel/panic.cpp
+++ b/kernel/kernel/panic.cpp
@@ -1,9 +1,9 @@
 /*
  * Copyright (c) 2016 - 2024 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  *
- * SPDX-License-Identifier: MIT
+ * SPDX-License-Identifier: GPL-2.0-only
  */
 /**************************************************************************
  *

--- a/kernel/kernel/percpu.cpp
+++ b/kernel/kernel/percpu.cpp
@@ -1,9 +1,9 @@
 /*
  * Copyright (c) 2919 - 2022 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  *
- * SPDX-License-Identifier: MIT
+ * SPDX-License-Identifier: GPL-2.0-only
  */
 
 #include <assert.h>

--- a/kernel/kernel/perf.cpp
+++ b/kernel/kernel/perf.cpp
@@ -1,9 +1,9 @@
 /*
  * Copyright (c) 2022 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  *
- * SPDX-License-Identifier: MIT
+ * SPDX-License-Identifier: GPL-2.0-only
  */
 
 #include <onyx/cpu.h>

--- a/kernel/kernel/photon/photon.cpp
+++ b/kernel/kernel/photon/photon.cpp
@@ -1,9 +1,9 @@
 /*
  * Copyright (c) 2020 - 2021 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  *
- * SPDX-License-Identifier: MIT
+ * SPDX-License-Identifier: GPL-2.0-only
  */
 
 #include <assert.h>

--- a/kernel/kernel/pid.cpp
+++ b/kernel/kernel/pid.cpp
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2020 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  */
 

--- a/kernel/kernel/power_management.cpp
+++ b/kernel/kernel/power_management.cpp
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2016-2020 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  */
 #include <errno.h>

--- a/kernel/kernel/proc_event.cpp
+++ b/kernel/kernel/proc_event.cpp
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2017 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  */
 

--- a/kernel/kernel/process.cpp
+++ b/kernel/kernel/process.cpp
@@ -1,9 +1,9 @@
 /*
  * Copyright (c) 2016 - 2024 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  *
- * SPDX-License-Identifier: MIT
+ * SPDX-License-Identifier: GPL-2.0-only
  */
 
 #include <assert.h>

--- a/kernel/kernel/radix.cpp
+++ b/kernel/kernel/radix.cpp
@@ -1,9 +1,9 @@
 /*
  * Copyright (c) 2022 - 2023 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  *
- * SPDX-License-Identifier: MIT
+ * SPDX-License-Identifier: GPL-2.0-only
  */
 #include <assert.h>
 #include <errno.h>

--- a/kernel/kernel/random.cpp
+++ b/kernel/kernel/random.cpp
@@ -1,9 +1,9 @@
 /*
  * Copyright (c) 2016 - 2022 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  *
- * SPDX-License-Identifier: MIT
+ * SPDX-License-Identifier: GPL-2.0-only
  */
 
 #include <assert.h>

--- a/kernel/kernel/rcupdate.cpp
+++ b/kernel/kernel/rcupdate.cpp
@@ -1,8 +1,8 @@
 /*
  * Copyright (c) 2023 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the LGPL-2.0-only license.
+ * This file is part of Onyx, and is released under the terms of the GPLv2 license.
  *
- * SPDX-License-Identifier: LGPL-2.0-only
+ * SPDX-License-Identifier: GPL-2.0-only
  */
 #include <onyx/clock.h>
 #include <onyx/cpumask.h>

--- a/kernel/kernel/ref.cpp
+++ b/kernel/kernel/ref.cpp
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2018 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  */
 

--- a/kernel/kernel/rlimit.cpp
+++ b/kernel/kernel/rlimit.cpp
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2021 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  */
 

--- a/kernel/kernel/sched/mutex.cpp
+++ b/kernel/kernel/sched/mutex.cpp
@@ -1,9 +1,9 @@
 /*
  * Copyright (c) 2020 - 2023 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  *
- * SPDX-License-Identifier: MIT
+ * SPDX-License-Identifier: GPL-2.0-only
  */
 #include <errno.h>
 

--- a/kernel/kernel/sched/primitive_generic.h
+++ b/kernel/kernel/sched/primitive_generic.h
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2020 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  */
 

--- a/kernel/kernel/sched/rwlock.cpp
+++ b/kernel/kernel/sched/rwlock.cpp
@@ -1,9 +1,9 @@
 /*
  * Copyright (c) 2017 - 2023 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  *
- * SPDX-License-Identifier: MIT
+ * SPDX-License-Identifier: GPL-2.0-only
  */
 #include <errno.h>
 

--- a/kernel/kernel/sched/scheduler.cpp
+++ b/kernel/kernel/sched/scheduler.cpp
@@ -1,9 +1,9 @@
 /*
  * Copyright (c) 2016 - 2024 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  *
- * SPDX-License-Identifier: MIT
+ * SPDX-License-Identifier: GPL-2.0-only
  */
 
 #include <assert.h>

--- a/kernel/kernel/sched/wait.cpp
+++ b/kernel/kernel/sched/wait.cpp
@@ -1,9 +1,9 @@
 /*
  * Copyright (c) 2021 - 2022 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  *
- * SPDX-License-Identifier: MIT
+ * SPDX-License-Identifier: GPL-2.0-only
  */
 
 #include <onyx/fnv.h>

--- a/kernel/kernel/sched/wait_impl.h
+++ b/kernel/kernel/sched/wait_impl.h
@@ -1,9 +1,9 @@
 /*
  * Copyright (c) 2021 - 2022 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  *
- * SPDX-License-Identifier: MIT
+ * SPDX-License-Identifier: GPL-2.0-only
  */
 
 #ifndef _ONYX_PRIVATE_WAIT_IMPL_H

--- a/kernel/kernel/signal.cpp
+++ b/kernel/kernel/signal.cpp
@@ -1,10 +1,9 @@
 /*
  * Copyright (c) 2016, 2017 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  */
 #include <errno.h>
-#include <uapi/signal.h>
 #include <stdio.h>
 
 #include <onyx/clock.h>
@@ -16,6 +15,8 @@
 #include <onyx/task_switching.h>
 #include <onyx/vm.h>
 #include <onyx/wait_queue.h>
+
+#include <uapi/signal.h>
 
 #include <onyx/memory.hpp>
 

--- a/kernel/kernel/smp.cpp
+++ b/kernel/kernel/smp.cpp
@@ -1,9 +1,9 @@
 /*
  * Copyright (c) 2019 - 2023 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  *
- * SPDX-License-Identifier: MIT
+ * SPDX-License-Identifier: GPL-2.0-only
  */
 #include <stdio.h>
 

--- a/kernel/kernel/softirq.cpp
+++ b/kernel/kernel/softirq.cpp
@@ -1,9 +1,9 @@
 /*
  * Copyright (c) 2020 - 2024 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  *
- * SPDX-License-Identifier: MIT
+ * SPDX-License-Identifier: GPL-2.0-only
  */
 
 #include <onyx/block.h>

--- a/kernel/kernel/spinlock.cpp
+++ b/kernel/kernel/spinlock.cpp
@@ -1,9 +1,9 @@
 /*
  * Copyright (c) 2016 - 2023 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  *
- * SPDX-License-Identifier: MIT
+ * SPDX-License-Identifier: GPL-2.0-only
  */
 #include <assert.h>
 #include <stdio.h>

--- a/kernel/kernel/ssp.cpp
+++ b/kernel/kernel/ssp.cpp
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2016, 2017 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  */
 /**************************************************************************

--- a/kernel/kernel/symbol.cpp
+++ b/kernel/kernel/symbol.cpp
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2019 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  */
 #include <string.h>

--- a/kernel/kernel/sysinfo.cpp
+++ b/kernel/kernel/sysinfo.cpp
@@ -1,9 +1,9 @@
 /*
  * Copyright (c) 2022 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  *
- * SPDX-License-Identifier: MIT
+ * SPDX-License-Identifier: GPL-2.0-only
  */
 
 #include <sys/sysinfo.h>

--- a/kernel/kernel/tasklet.cpp
+++ b/kernel/kernel/tasklet.cpp
@@ -1,9 +1,9 @@
 /*
  * Copyright (c) 2023 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  *
- * SPDX-License-Identifier: MIT
+ * SPDX-License-Identifier: GPL-2.0-only
  */
 #include <assert.h>
 

--- a/kernel/kernel/time.cpp
+++ b/kernel/kernel/time.cpp
@@ -1,9 +1,9 @@
 /*
  * Copyright (c) 2016 - 2024 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  *
- * SPDX-License-Identifier: MIT
+ * SPDX-License-Identifier: GPL-2.0-only
  */
 
 #include <assert.h>

--- a/kernel/kernel/timer.cpp
+++ b/kernel/kernel/timer.cpp
@@ -1,9 +1,9 @@
 /*
  * Copyright (c) 2019 - 2022 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  *
- * SPDX-License-Identifier: MIT
+ * SPDX-License-Identifier: GPL-2.0-only
  */
 #include <errno.h>
 #include <string.h>

--- a/kernel/kernel/tty/n_tty.cpp
+++ b/kernel/kernel/tty/n_tty.cpp
@@ -1,9 +1,9 @@
 /*
  * Copyright (c) 2020 - 2022 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  *
- * SPDX-License-Identifier: MIT
+ * SPDX-License-Identifier: GPL-2.0-only
  */
 #include <ctype.h>
 

--- a/kernel/kernel/tty/pty.c
+++ b/kernel/kernel/tty/pty.c
@@ -1,9 +1,9 @@
 /*
  * Copyright (c) 2024 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  *
- * SPDX-License-Identifier: MIT
+ * SPDX-License-Identifier: GPL-2.0-only
  */
 
 #include <onyx/init.h>

--- a/kernel/kernel/tty/serial.cpp
+++ b/kernel/kernel/tty/serial.cpp
@@ -1,9 +1,9 @@
 /*
  * Copyright (c) 2022 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  *
- * SPDX-License-Identifier: MIT
+ * SPDX-License-Identifier: GPL-2.0-only
  */
 
 #include <onyx/dpc.h>

--- a/kernel/kernel/tty/tty.cpp
+++ b/kernel/kernel/tty/tty.cpp
@@ -1,9 +1,9 @@
 /*
  * Copyright (c) 2016 - 2024 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  *
- * SPDX-License-Identifier: MIT
+ * SPDX-License-Identifier: GPL-2.0-only
  */
 /**************************************************************************
  *

--- a/kernel/kernel/tty/vt/vterm.cpp
+++ b/kernel/kernel/tty/vt/vterm.cpp
@@ -1,9 +1,9 @@
 /*
  * Copyright (c) 2018 - 2024 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  *
- * SPDX-License-Identifier: MIT
+ * SPDX-License-Identifier: GPL-2.0-only
  */
 #include <assert.h>
 #include <ctype.h>

--- a/kernel/kernel/ubsan.cpp
+++ b/kernel/kernel/ubsan.cpp
@@ -1,9 +1,9 @@
 /*
  * Copyright (c) 2022 - 2023 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  *
- * SPDX-License-Identifier: MIT
+ * SPDX-License-Identifier: GPL-2.0-only
  */
 
 #include <assert.h>

--- a/kernel/kernel/uname.cpp
+++ b/kernel/kernel/uname.cpp
@@ -1,9 +1,9 @@
 /*
  * Copyright (c) 2016 - 2022 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  *
- * SPDX-License-Identifier: MIT
+ * SPDX-License-Identifier: GPL-2.0-only
  */
 #include <errno.h>
 #include <stdlib.h>

--- a/kernel/kernel/utils.cpp
+++ b/kernel/kernel/utils.cpp
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2017 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  */
 #include <stdlib.h>

--- a/kernel/kernel/vdso.cpp
+++ b/kernel/kernel/vdso.cpp
@@ -1,9 +1,9 @@
 /*
  * Copyright (c) 2016 - 2023 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  *
- * SPDX-License-Identifier: MIT
+ * SPDX-License-Identifier: GPL-2.0-only
  */
 #include <assert.h>
 #include <elf.h>

--- a/kernel/kernel/wait_queue.cpp
+++ b/kernel/kernel/wait_queue.cpp
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2019 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  */
 #include <stddef.h>

--- a/kernel/kernel/worker.cpp
+++ b/kernel/kernel/worker.cpp
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2017 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  */
 #include <errno.h>

--- a/kernel/lib/binary_search_tree/augmented-test.cpp
+++ b/kernel/lib/binary_search_tree/augmented-test.cpp
@@ -1,9 +1,9 @@
 /*
  * Copyright (c) 2023 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  *
- * SPDX-License-Identifier: MIT
+ * SPDX-License-Identifier: GPL-2.0-only
  */
 #include <stdio.h>
 

--- a/kernel/lib/device_tree/device_tree.cpp
+++ b/kernel/lib/device_tree/device_tree.cpp
@@ -1,9 +1,9 @@
 /*
  * Copyright (c) 2022 - 2023 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  *
- * SPDX-License-Identifier: MIT
+ * SPDX-License-Identifier: GPL-2.0-only
  */
 
 #include <stdio.h>

--- a/kernel/lib/interval_tree/interval_tree.c
+++ b/kernel/lib/interval_tree/interval_tree.c
@@ -1,9 +1,9 @@
 /*
  * Copyright (c) 2023 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  *
- * SPDX-License-Identifier: MIT
+ * SPDX-License-Identifier: GPL-2.0-only
  */
 
 #include <onyx/interval_tree.h>

--- a/kernel/lib/interval_tree/interval_tree_test.cpp
+++ b/kernel/lib/interval_tree/interval_tree_test.cpp
@@ -1,9 +1,9 @@
 /*
  * Copyright (c) 2023 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  *
- * SPDX-License-Identifier: MIT
+ * SPDX-License-Identifier: GPL-2.0-only
  */
 
 #include <stdio.h>

--- a/kernel/lib/libk/arch/x86_64/memcpy.S
+++ b/kernel/lib/libk/arch/x86_64/memcpy.S
@@ -1,9 +1,9 @@
 /*
  * Copyright (c) 2023 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  *
- * SPDX-License-Identifier: MIT
+ * SPDX-License-Identifier: GPL-2.0-only
  */
 #include "memcpy_impl.S"
 

--- a/kernel/lib/libk/arch/x86_64/memcpy_impl.S
+++ b/kernel/lib/libk/arch/x86_64/memcpy_impl.S
@@ -1,9 +1,9 @@
 /*
  * Copyright (c) 2023 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  *
- * SPDX-License-Identifier: MIT
+ * SPDX-License-Identifier: GPL-2.0-only
  */
 #include <onyx/x86/asm.h>
 #define ALIGN_TEXT .p2align 4, 0x90

--- a/kernel/lib/libk/arch/x86_64/memset.S
+++ b/kernel/lib/libk/arch/x86_64/memset.S
@@ -1,9 +1,9 @@
 /*
  * Copyright (c) 2023 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  *
- * SPDX-License-Identifier: MIT
+ * SPDX-License-Identifier: GPL-2.0-only
  */
 #include "memset_impl.S"
 

--- a/kernel/lib/libk/arch/x86_64/memset_impl.S
+++ b/kernel/lib/libk/arch/x86_64/memset_impl.S
@@ -1,9 +1,9 @@
 /*
  * Copyright (c) 2023 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  *
- * SPDX-License-Identifier: MIT
+ * SPDX-License-Identifier: GPL-2.0-only
  */
 #define RET ret
 #define ALIGN_TEXT .p2align 4, 0x90

--- a/kernel/lib/libk/ctype/to.c
+++ b/kernel/lib/libk/ctype/to.c
@@ -1,9 +1,9 @@
 /*
  * Copyright (c) 2016 - 2021 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  *
- * SPDX-License-Identifier: MIT
+ * SPDX-License-Identifier: GPL-2.0-only
  */
 #include <ctype.h>
 

--- a/kernel/lib/libk/include/sys/cdefs.h
+++ b/kernel/lib/libk/include/sys/cdefs.h
@@ -1,6 +1,6 @@
 /*
 * Copyright (c) 2016, 2017 Pedro Falcato
-* This file is part of Onyx, and is released under the terms of the MIT License
+* This file is part of Onyx, and is released under the terms of the GPLv2 License
 * check LICENSE at the root directory for more information
 */
 #ifndef _SYS_CDEFS_H

--- a/kernel/lib/libk/libc/__tls_get_addr.c
+++ b/kernel/lib/libk/libc/__tls_get_addr.c
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2016, 2017 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  */
 /**************************************************************************

--- a/kernel/lib/libk/libc/init.c
+++ b/kernel/lib/libk/libc/init.c
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2016, 2017 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  */
 #include <stdio.h>

--- a/kernel/lib/libk/posix/io.c
+++ b/kernel/lib/libk/posix/io.c
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2016, 2017 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  */
 #include <stdio.h>

--- a/kernel/lib/libk/posix/memory.c
+++ b/kernel/lib/libk/posix/memory.c
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2016, 2017 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  */
 #include <stdlib.h>

--- a/kernel/lib/libk/posix/signal.c
+++ b/kernel/lib/libk/posix/signal.c
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2016, 2017 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  */
 #include <uapi/signal.h>

--- a/kernel/lib/libk/posix/time.c
+++ b/kernel/lib/libk/posix/time.c
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2016, 2017 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  */
 #include <stdio.h>

--- a/kernel/lib/libk/posix/uio.c
+++ b/kernel/lib/libk/posix/uio.c
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2016, 2017 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  */
 #include <sys/syscall.h>

--- a/kernel/lib/libk/stdio/fclose.c
+++ b/kernel/lib/libk/stdio/fclose.c
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2016, 2017 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  */
 #include <stdio.h>

--- a/kernel/lib/libk/stdio/fgets.c
+++ b/kernel/lib/libk/stdio/fgets.c
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2016, 2017 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  */
 #include <stdio.h>

--- a/kernel/lib/libk/stdio/fopen.c
+++ b/kernel/lib/libk/stdio/fopen.c
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2016, 2017 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  */
 #include <stddef.h>

--- a/kernel/lib/libk/stdio/fprintf.c
+++ b/kernel/lib/libk/stdio/fprintf.c
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2016, 2017 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  */
 #include <stdarg.h>

--- a/kernel/lib/libk/stdio/fread.c
+++ b/kernel/lib/libk/stdio/fread.c
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2016, 2017 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  */
 #include <stddef.h>

--- a/kernel/lib/libk/stdio/fseek.c
+++ b/kernel/lib/libk/stdio/fseek.c
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2016, 2017 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  */
 #include <stddef.h>

--- a/kernel/lib/libk/stdio/ftell.c
+++ b/kernel/lib/libk/stdio/ftell.c
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2016, 2017 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  */
 #include <stddef.h>

--- a/kernel/lib/libk/stdio/fwrite.c
+++ b/kernel/lib/libk/stdio/fwrite.c
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2016, 2017 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  */
 #include <stddef.h>

--- a/kernel/lib/libk/stdio/gets.c
+++ b/kernel/lib/libk/stdio/gets.c
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2016, 2017 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  */
 #include <stdio.h>

--- a/kernel/lib/libk/stdio/perror.c
+++ b/kernel/lib/libk/stdio/perror.c
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2016, 2017 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  */
 #include <errno.h>

--- a/kernel/lib/libk/stdio/putchar.c
+++ b/kernel/lib/libk/stdio/putchar.c
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2016, 2017 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  */
 #include <stdio.h>

--- a/kernel/lib/libk/stdio/puts.c
+++ b/kernel/lib/libk/stdio/puts.c
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2016, 2017 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  */
 #include <stdio.h>

--- a/kernel/lib/libk/stdio/rewind.c
+++ b/kernel/lib/libk/stdio/rewind.c
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2016, 2017 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  */
 #include <stddef.h>

--- a/kernel/lib/libk/stdio/sprintf.c
+++ b/kernel/lib/libk/stdio/sprintf.c
@@ -1,9 +1,9 @@
 /*
  * Copyright (c) 2024 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  *
- * SPDX-License-Identifier: MIT
+ * SPDX-License-Identifier: GPL-2.0-only
  */
 #include <ctype.h>
 #include <limits.h>

--- a/kernel/lib/libk/stdio/stdio.c
+++ b/kernel/lib/libk/stdio/stdio.c
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2016, 2017 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  */
 #include <errno.h>

--- a/kernel/lib/libk/stdio/stdio_impl.h
+++ b/kernel/lib/libk/stdio/stdio_impl.h
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2016, 2017 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  */
 #ifndef _STDIO_IMPL_H

--- a/kernel/lib/libk/stdio/stdstream.c
+++ b/kernel/lib/libk/stdio/stdstream.c
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2016, 2017 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  */
 #include <stdio.h>

--- a/kernel/lib/libk/stdio/tmpnam.c
+++ b/kernel/lib/libk/stdio/tmpnam.c
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2016, 2017 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  */
 #include <ctype.h>

--- a/kernel/lib/libk/stdlib/_Exit.c
+++ b/kernel/lib/libk/stdlib/_Exit.c
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2016, 2017 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  */
 #include <unistd.h>

--- a/kernel/lib/libk/stdlib/abort.c
+++ b/kernel/lib/libk/stdlib/abort.c
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2016, 2017 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  */
 #ifdef __is_onyx_kernel

--- a/kernel/lib/libk/stdlib/rand.c
+++ b/kernel/lib/libk/stdlib/rand.c
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2021 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  */
 

--- a/kernel/lib/libk/string/memccpy.c
+++ b/kernel/lib/libk/string/memccpy.c
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2016, 2017 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  */
 #include <stdlib.h>

--- a/kernel/lib/libk/string/memchr.c
+++ b/kernel/lib/libk/string/memchr.c
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2016, 2017 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  */
 #include <string.h>

--- a/kernel/lib/libk/string/memcmp.c
+++ b/kernel/lib/libk/string/memcmp.c
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2016, 2017 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  */
 #include <string.h>

--- a/kernel/lib/libk/string/memcpy.c
+++ b/kernel/lib/libk/string/memcpy.c
@@ -1,9 +1,9 @@
 /*
  * Copyright (c) 2016 - 2022 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  *
- * SPDX-License-Identifier: MIT
+ * SPDX-License-Identifier: GPL-2.0-only
  */
 #include <stdint.h>
 #include <string.h>

--- a/kernel/lib/libk/string/memset.c
+++ b/kernel/lib/libk/string/memset.c
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2016, 2017 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  */
 #include <stdint.h>

--- a/kernel/lib/libk/string/memset_explicit.c
+++ b/kernel/lib/libk/string/memset_explicit.c
@@ -1,9 +1,9 @@
 /*
  * Copyright (c) 2016 - 2023 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  *
- * SPDX-License-Identifier: MIT
+ * SPDX-License-Identifier: GPL-2.0-only
  */
 
 #include <string.h>

--- a/kernel/lib/libk/string/stpcpy.c
+++ b/kernel/lib/libk/string/stpcpy.c
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2016, 2017 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  */
 

--- a/kernel/lib/libk/string/strcat.c
+++ b/kernel/lib/libk/string/strcat.c
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2016, 2017 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  */
 #include <string.h>

--- a/kernel/lib/libk/string/strchr.c
+++ b/kernel/lib/libk/string/strchr.c
@@ -1,9 +1,9 @@
 /*
  * Copyright (c) 2020 - 2023 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  *
- * SPDX-License-Identifier: MIT
+ * SPDX-License-Identifier: GPL-2.0-only
  */
 #include <string.h>
 

--- a/kernel/lib/libk/string/strcmp.c
+++ b/kernel/lib/libk/string/strcmp.c
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2016, 2017 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  */
 #include <string.h>

--- a/kernel/lib/libk/string/strcpy.c
+++ b/kernel/lib/libk/string/strcpy.c
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2016-2020 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  */
 #include <string.h>

--- a/kernel/lib/libk/string/strdup.c
+++ b/kernel/lib/libk/string/strdup.c
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2017 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  */
 #include <errno.h>

--- a/kernel/lib/libk/string/strerror.c
+++ b/kernel/lib/libk/string/strerror.c
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2016, 2017 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  */
 const char *errno_table[] = {"Operation not permitted",

--- a/kernel/lib/libk/string/strlen.cpp
+++ b/kernel/lib/libk/string/strlen.cpp
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2020 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  */
 

--- a/kernel/lib/libk/string/wmemcpy.c
+++ b/kernel/lib/libk/string/wmemcpy.c
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2016, 2017 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  */
 #include <string.h>

--- a/kernel/lib/libk/sys/syscall.c
+++ b/kernel/lib/libk/sys/syscall.c
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2016, 2017 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  */
 #include <stdarg.h>

--- a/kernel/lib/stackdepot/stackdepot.cpp
+++ b/kernel/lib/stackdepot/stackdepot.cpp
@@ -1,9 +1,9 @@
 /*
  * Copyright (c) 2023 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  *
- * SPDX-License-Identifier: MIT
+ * SPDX-License-Identifier: GPL-2.0-only
  */
 #include <onyx/fnv.h>
 #include <onyx/mm/slab.h>

--- a/kernel/lib/string_parsing/string_parsing.cpp
+++ b/kernel/lib/string_parsing/string_parsing.cpp
@@ -1,9 +1,9 @@
 /*
  * Copyright (c) 2021 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  *
- * SPDX-License-Identifier: MIT
+ * SPDX-License-Identifier: GPL-2.0-only
  */
 
 #include <ctype.h>

--- a/kernel/lib/zstd/module.cpp
+++ b/kernel/lib/zstd/module.cpp
@@ -1,9 +1,9 @@
 /*
  * Copyright (c) 2022 Pedro Falcato
- * This file is part of Onyx, and is released under the terms of the MIT License
+ * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  *
- * SPDX-License-Identifier: MIT
+ * SPDX-License-Identifier: GPL-2.0-only
  */
 
 #include <errno.h>

--- a/licenses/GPL-2.0
+++ b/licenses/GPL-2.0
@@ -1,0 +1,339 @@
+                    GNU GENERAL PUBLIC LICENSE
+                       Version 2, June 1991
+
+ Copyright (C) 1989, 1991 Free Software Foundation, Inc.,
+ 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+ Everyone is permitted to copy and distribute verbatim copies
+ of this license document, but changing it is not allowed.
+
+                            Preamble
+
+  The licenses for most software are designed to take away your
+freedom to share and change it.  By contrast, the GNU General Public
+License is intended to guarantee your freedom to share and change free
+software--to make sure the software is free for all its users.  This
+General Public License applies to most of the Free Software
+Foundation's software and to any other program whose authors commit to
+using it.  (Some other Free Software Foundation software is covered by
+the GNU Lesser General Public License instead.)  You can apply it to
+your programs, too.
+
+  When we speak of free software, we are referring to freedom, not
+price.  Our General Public Licenses are designed to make sure that you
+have the freedom to distribute copies of free software (and charge for
+this service if you wish), that you receive source code or can get it
+if you want it, that you can change the software or use pieces of it
+in new free programs; and that you know you can do these things.
+
+  To protect your rights, we need to make restrictions that forbid
+anyone to deny you these rights or to ask you to surrender the rights.
+These restrictions translate to certain responsibilities for you if you
+distribute copies of the software, or if you modify it.
+
+  For example, if you distribute copies of such a program, whether
+gratis or for a fee, you must give the recipients all the rights that
+you have.  You must make sure that they, too, receive or can get the
+source code.  And you must show them these terms so they know their
+rights.
+
+  We protect your rights with two steps: (1) copyright the software, and
+(2) offer you this license which gives you legal permission to copy,
+distribute and/or modify the software.
+
+  Also, for each author's protection and ours, we want to make certain
+that everyone understands that there is no warranty for this free
+software.  If the software is modified by someone else and passed on, we
+want its recipients to know that what they have is not the original, so
+that any problems introduced by others will not reflect on the original
+authors' reputations.
+
+  Finally, any free program is threatened constantly by software
+patents.  We wish to avoid the danger that redistributors of a free
+program will individually obtain patent licenses, in effect making the
+program proprietary.  To prevent this, we have made it clear that any
+patent must be licensed for everyone's free use or not licensed at all.
+
+  The precise terms and conditions for copying, distribution and
+modification follow.
+
+                    GNU GENERAL PUBLIC LICENSE
+   TERMS AND CONDITIONS FOR COPYING, DISTRIBUTION AND MODIFICATION
+
+  0. This License applies to any program or other work which contains
+a notice placed by the copyright holder saying it may be distributed
+under the terms of this General Public License.  The "Program", below,
+refers to any such program or work, and a "work based on the Program"
+means either the Program or any derivative work under copyright law:
+that is to say, a work containing the Program or a portion of it,
+either verbatim or with modifications and/or translated into another
+language.  (Hereinafter, translation is included without limitation in
+the term "modification".)  Each licensee is addressed as "you".
+
+Activities other than copying, distribution and modification are not
+covered by this License; they are outside its scope.  The act of
+running the Program is not restricted, and the output from the Program
+is covered only if its contents constitute a work based on the
+Program (independent of having been made by running the Program).
+Whether that is true depends on what the Program does.
+
+  1. You may copy and distribute verbatim copies of the Program's
+source code as you receive it, in any medium, provided that you
+conspicuously and appropriately publish on each copy an appropriate
+copyright notice and disclaimer of warranty; keep intact all the
+notices that refer to this License and to the absence of any warranty;
+and give any other recipients of the Program a copy of this License
+along with the Program.
+
+You may charge a fee for the physical act of transferring a copy, and
+you may at your option offer warranty protection in exchange for a fee.
+
+  2. You may modify your copy or copies of the Program or any portion
+of it, thus forming a work based on the Program, and copy and
+distribute such modifications or work under the terms of Section 1
+above, provided that you also meet all of these conditions:
+
+    a) You must cause the modified files to carry prominent notices
+    stating that you changed the files and the date of any change.
+
+    b) You must cause any work that you distribute or publish, that in
+    whole or in part contains or is derived from the Program or any
+    part thereof, to be licensed as a whole at no charge to all third
+    parties under the terms of this License.
+
+    c) If the modified program normally reads commands interactively
+    when run, you must cause it, when started running for such
+    interactive use in the most ordinary way, to print or display an
+    announcement including an appropriate copyright notice and a
+    notice that there is no warranty (or else, saying that you provide
+    a warranty) and that users may redistribute the program under
+    these conditions, and telling the user how to view a copy of this
+    License.  (Exception: if the Program itself is interactive but
+    does not normally print such an announcement, your work based on
+    the Program is not required to print an announcement.)
+
+These requirements apply to the modified work as a whole.  If
+identifiable sections of that work are not derived from the Program,
+and can be reasonably considered independent and separate works in
+themselves, then this License, and its terms, do not apply to those
+sections when you distribute them as separate works.  But when you
+distribute the same sections as part of a whole which is a work based
+on the Program, the distribution of the whole must be on the terms of
+this License, whose permissions for other licensees extend to the
+entire whole, and thus to each and every part regardless of who wrote it.
+
+Thus, it is not the intent of this section to claim rights or contest
+your rights to work written entirely by you; rather, the intent is to
+exercise the right to control the distribution of derivative or
+collective works based on the Program.
+
+In addition, mere aggregation of another work not based on the Program
+with the Program (or with a work based on the Program) on a volume of
+a storage or distribution medium does not bring the other work under
+the scope of this License.
+
+  3. You may copy and distribute the Program (or a work based on it,
+under Section 2) in object code or executable form under the terms of
+Sections 1 and 2 above provided that you also do one of the following:
+
+    a) Accompany it with the complete corresponding machine-readable
+    source code, which must be distributed under the terms of Sections
+    1 and 2 above on a medium customarily used for software interchange; or,
+
+    b) Accompany it with a written offer, valid for at least three
+    years, to give any third party, for a charge no more than your
+    cost of physically performing source distribution, a complete
+    machine-readable copy of the corresponding source code, to be
+    distributed under the terms of Sections 1 and 2 above on a medium
+    customarily used for software interchange; or,
+
+    c) Accompany it with the information you received as to the offer
+    to distribute corresponding source code.  (This alternative is
+    allowed only for noncommercial distribution and only if you
+    received the program in object code or executable form with such
+    an offer, in accord with Subsection b above.)
+
+The source code for a work means the preferred form of the work for
+making modifications to it.  For an executable work, complete source
+code means all the source code for all modules it contains, plus any
+associated interface definition files, plus the scripts used to
+control compilation and installation of the executable.  However, as a
+special exception, the source code distributed need not include
+anything that is normally distributed (in either source or binary
+form) with the major components (compiler, kernel, and so on) of the
+operating system on which the executable runs, unless that component
+itself accompanies the executable.
+
+If distribution of executable or object code is made by offering
+access to copy from a designated place, then offering equivalent
+access to copy the source code from the same place counts as
+distribution of the source code, even though third parties are not
+compelled to copy the source along with the object code.
+
+  4. You may not copy, modify, sublicense, or distribute the Program
+except as expressly provided under this License.  Any attempt
+otherwise to copy, modify, sublicense or distribute the Program is
+void, and will automatically terminate your rights under this License.
+However, parties who have received copies, or rights, from you under
+this License will not have their licenses terminated so long as such
+parties remain in full compliance.
+
+  5. You are not required to accept this License, since you have not
+signed it.  However, nothing else grants you permission to modify or
+distribute the Program or its derivative works.  These actions are
+prohibited by law if you do not accept this License.  Therefore, by
+modifying or distributing the Program (or any work based on the
+Program), you indicate your acceptance of this License to do so, and
+all its terms and conditions for copying, distributing or modifying
+the Program or works based on it.
+
+  6. Each time you redistribute the Program (or any work based on the
+Program), the recipient automatically receives a license from the
+original licensor to copy, distribute or modify the Program subject to
+these terms and conditions.  You may not impose any further
+restrictions on the recipients' exercise of the rights granted herein.
+You are not responsible for enforcing compliance by third parties to
+this License.
+
+  7. If, as a consequence of a court judgment or allegation of patent
+infringement or for any other reason (not limited to patent issues),
+conditions are imposed on you (whether by court order, agreement or
+otherwise) that contradict the conditions of this License, they do not
+excuse you from the conditions of this License.  If you cannot
+distribute so as to satisfy simultaneously your obligations under this
+License and any other pertinent obligations, then as a consequence you
+may not distribute the Program at all.  For example, if a patent
+license would not permit royalty-free redistribution of the Program by
+all those who receive copies directly or indirectly through you, then
+the only way you could satisfy both it and this License would be to
+refrain entirely from distribution of the Program.
+
+If any portion of this section is held invalid or unenforceable under
+any particular circumstance, the balance of the section is intended to
+apply and the section as a whole is intended to apply in other
+circumstances.
+
+It is not the purpose of this section to induce you to infringe any
+patents or other property right claims or to contest validity of any
+such claims; this section has the sole purpose of protecting the
+integrity of the free software distribution system, which is
+implemented by public license practices.  Many people have made
+generous contributions to the wide range of software distributed
+through that system in reliance on consistent application of that
+system; it is up to the author/donor to decide if he or she is willing
+to distribute software through any other system and a licensee cannot
+impose that choice.
+
+This section is intended to make thoroughly clear what is believed to
+be a consequence of the rest of this License.
+
+  8. If the distribution and/or use of the Program is restricted in
+certain countries either by patents or by copyrighted interfaces, the
+original copyright holder who places the Program under this License
+may add an explicit geographical distribution limitation excluding
+those countries, so that distribution is permitted only in or among
+countries not thus excluded.  In such case, this License incorporates
+the limitation as if written in the body of this License.
+
+  9. The Free Software Foundation may publish revised and/or new versions
+of the General Public License from time to time.  Such new versions will
+be similar in spirit to the present version, but may differ in detail to
+address new problems or concerns.
+
+Each version is given a distinguishing version number.  If the Program
+specifies a version number of this License which applies to it and "any
+later version", you have the option of following the terms and conditions
+either of that version or of any later version published by the Free
+Software Foundation.  If the Program does not specify a version number of
+this License, you may choose any version ever published by the Free Software
+Foundation.
+
+  10. If you wish to incorporate parts of the Program into other free
+programs whose distribution conditions are different, write to the author
+to ask for permission.  For software which is copyrighted by the Free
+Software Foundation, write to the Free Software Foundation; we sometimes
+make exceptions for this.  Our decision will be guided by the two goals
+of preserving the free status of all derivatives of our free software and
+of promoting the sharing and reuse of software generally.
+
+                            NO WARRANTY
+
+  11. BECAUSE THE PROGRAM IS LICENSED FREE OF CHARGE, THERE IS NO WARRANTY
+FOR THE PROGRAM, TO THE EXTENT PERMITTED BY APPLICABLE LAW.  EXCEPT WHEN
+OTHERWISE STATED IN WRITING THE COPYRIGHT HOLDERS AND/OR OTHER PARTIES
+PROVIDE THE PROGRAM "AS IS" WITHOUT WARRANTY OF ANY KIND, EITHER EXPRESSED
+OR IMPLIED, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE.  THE ENTIRE RISK AS
+TO THE QUALITY AND PERFORMANCE OF THE PROGRAM IS WITH YOU.  SHOULD THE
+PROGRAM PROVE DEFECTIVE, YOU ASSUME THE COST OF ALL NECESSARY SERVICING,
+REPAIR OR CORRECTION.
+
+  12. IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN WRITING
+WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MAY MODIFY AND/OR
+REDISTRIBUTE THE PROGRAM AS PERMITTED ABOVE, BE LIABLE TO YOU FOR DAMAGES,
+INCLUDING ANY GENERAL, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES ARISING
+OUT OF THE USE OR INABILITY TO USE THE PROGRAM (INCLUDING BUT NOT LIMITED
+TO LOSS OF DATA OR DATA BEING RENDERED INACCURATE OR LOSSES SUSTAINED BY
+YOU OR THIRD PARTIES OR A FAILURE OF THE PROGRAM TO OPERATE WITH ANY OTHER
+PROGRAMS), EVEN IF SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE
+POSSIBILITY OF SUCH DAMAGES.
+
+                     END OF TERMS AND CONDITIONS
+
+            How to Apply These Terms to Your New Programs
+
+  If you develop a new program, and you want it to be of the greatest
+possible use to the public, the best way to achieve this is to make it
+free software which everyone can redistribute and change under these terms.
+
+  To do so, attach the following notices to the program.  It is safest
+to attach them to the start of each source file to most effectively
+convey the exclusion of warranty; and each file should have at least
+the "copyright" line and a pointer to where the full notice is found.
+
+    <one line to give the program's name and a brief idea of what it does.>
+    Copyright (C) <year>  <name of author>
+
+    This program is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 2 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License along
+    with this program; if not, write to the Free Software Foundation, Inc.,
+    51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+Also add information on how to contact you by electronic and paper mail.
+
+If the program is interactive, make it output a short notice like this
+when it starts in an interactive mode:
+
+    Gnomovision version 69, Copyright (C) year name of author
+    Gnomovision comes with ABSOLUTELY NO WARRANTY; for details type `show w'.
+    This is free software, and you are welcome to redistribute it
+    under certain conditions; type `show c' for details.
+
+The hypothetical commands `show w' and `show c' should show the appropriate
+parts of the General Public License.  Of course, the commands you use may
+be called something other than `show w' and `show c'; they could even be
+mouse-clicks or menu items--whatever suits your program.
+
+You should also get your employer (if you work as a programmer) or your
+school, if any, to sign a "copyright disclaimer" for the program, if
+necessary.  Here is a sample; alter the names:
+
+  Yoyodyne, Inc., hereby disclaims all copyright interest in the program
+  `Gnomovision' (which makes passes at compilers) written by James Hacker.
+
+  <signature of Ty Coon>, 1 April 1989
+  Ty Coon, President of Vice
+
+This General Public License does not permit incorporating your program into
+proprietary programs.  If your program is a subroutine library, you may
+consider it more useful to permit linking proprietary applications with the
+library.  If this is what you want to do, use the GNU Lesser General
+Public License instead of this License.

--- a/licenses/MIT
+++ b/licenses/MIT
@@ -1,0 +1,20 @@
+Copyright (c) 2017 - 2024 Pedro Falcato
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+


### PR DESCRIPTION
Relicense the whole of the kernel to GPLv2 (only). Driver licensing is untouched, and so are a few of other files.

This move is prompted by a couple of reasons:
 - MIT was a poor license choice for a project I care deeply about. I've spent countless hours working on this. MIT requires little to no attribution, and allows relicensing at will (to e.g proprietary)
 - GPL will allow us to dig into cooler ideas (from e.g Linux) and allow me to use RCU more freely, without patent worries

@petershh comments on this move? or just ack since you're actually a copyright holder for a few files (pipe.cpp, tty.cpp, socket.cpp)