### PR TITLE
riscv/signal: Fix the build on clang

### DIFF
--- a/kernel/arch/riscv64/signal.cpp
+++ b/kernel/arch/riscv64/signal.cpp
@@ -144,7 +144,7 @@ static void deliver_signal(struct arch_siginfo *sinfo, struct registers *regs)
         /* Only restart ERESTARTSYS (if SA_RESTART) and ERESTARTNOINTR. ERESTART_RESTARTBLOCK is
          * only supposed to be used for SIGSTOP help, and ERESTARTNOHAND never restarts if there is
          * a handler we're dispatching to (poll, pause, sigsuspend, etc) */
-        switch (regs->a0)
+        switch ((long) regs->a0)
         {
             case -ERESTARTSYS:
                 if (!(ksa->sa_flags & SA_RESTART))
@@ -195,7 +195,7 @@ void handle_signal(struct registers *regs)
      * ERESTARTNOINTR and ERESTART_RESTARTBLOCK */
     if (in_syscall(regs))
     {
-        switch (regs->a0)
+        switch ((long) regs->a0)
         {
             case -ERESTARTNOHAND:
             case -ERESTARTNOINTR:


### PR DESCRIPTION
CI is failing with this error:

2025-03-12T04:33:28.2874007Z arch/riscv64/signal.cpp:149:18: error: case value evaluates to -512, which cannot be narrowed to type 'unsigned long' [-Wc++11-narrowing]
2025-03-12T04:33:28.2878316Z             case -ERESTARTSYS:
2025-03-12T04:33:28.2879038Z                  ^
2025-03-12T04:33:28.2879932Z arch/riscv64/signal.cpp:156:18: error: case value evaluates to -513, which cannot be narrowed to type 'unsigned long' [-Wc++11-narrowing]
2025-03-12T04:33:28.2880908Z             case -ERESTARTNOINTR:
2025-03-12T04:33:28.2881303Z                  ^
2025-03-12T04:33:28.2882312Z arch/riscv64/signal.cpp:161:18: error: case value evaluates to -516, which cannot be narrowed to type 'unsigned long' [-Wc++11-narrowing]
2025-03-12T04:33:28.2883233Z             case -ERESTART_RESTARTBLOCK:
2025-03-12T04:33:28.2883634Z                  ^
2025-03-12T04:33:28.2884537Z arch/riscv64/signal.cpp:162:18: error: case value evaluates to -514, which cannot be narrowed to type 'unsigned long' [-Wc++11-narrowing]
2025-03-12T04:33:28.2885480Z             case -ERESTARTNOHAND:

Fix it by casting.