### PR TITLE
creds: Add various missing set*id() and get*id() syscalls

### DIFF
--- a/kernel/arch/riscv64/syscall_table.json
+++ b/kernel/arch/riscv64/syscall_table.json
@@ -2938,12 +2938,12 @@
                 "parent_tidptr"
             ],
             [
-                "int *",
-                "child_tidptr"
-            ],
-            [
                 "unsigned long",
                 "tls"
+            ],
+            [
+                "int *",
+                "child_tidptr"
             ]
         ],
         "return_type": "int",

--- a/kernel/arch/riscv64/syscall_table.json
+++ b/kernel/arch/riscv64/syscall_table.json
@@ -2948,5 +2948,131 @@
         ],
         "return_type": "int",
         "abi": "c"
+    },
+    {
+        "name": "getresuid",
+        "nr": 166,
+        "nr_args": 3,
+        "args": [
+            [
+                "uid_t *",
+                "ruid"
+            ],
+            [
+                "uid_t *",
+                "euid"
+            ],
+            [
+                "uid_t *",
+                "suid"
+            ]
+        ],
+        "return_type": "int"
+    },
+    {
+        "name": "getresgid",
+        "nr": 167,
+        "nr_args": 3,
+        "args": [
+            [
+                "gid_t *",
+                "rgid"
+            ],
+            [
+                "gid_t *",
+                "egid"
+            ],
+            [
+                "gid_t *",
+                "sgid"
+            ]
+        ],
+        "return_type": "int"
+    },
+    {
+        "name": "setresuid",
+        "nr": 168,
+        "nr_args": 3,
+        "args": [
+            [
+                "uid_t",
+                "ruid"
+            ],
+            [
+                "uid_t",
+                "euid"
+            ],
+            [
+                "uid_t",
+                "suid"
+            ]
+        ],
+        "return_type": "int"
+    },
+    {
+        "name": "setresgid",
+        "nr": 169,
+        "nr_args": 3,
+        "args": [
+            [
+                "gid_t",
+                "rgid"
+            ],
+            [
+                "gid_t",
+                "egid"
+            ],
+            [
+                "gid_t",
+                "sgid"
+            ]
+        ],
+        "return_type": "int"
+    },
+    {
+        "name": "setreuid",
+        "nr": 170,
+        "nr_args": 2,
+        "args": [
+            [
+                "uid_t",
+                "ruid"
+            ],
+            [
+                "uid_t",
+                "euid"
+            ]
+        ],
+        "return_type": "int"
+    },
+    {
+        "name": "setregid",
+        "nr": 171,
+        "nr_args": 2,
+        "args": [
+            [
+                "gid_t",
+                "rgid"
+            ],
+            [
+                "gid_t",
+                "egid"
+            ]
+        ],
+        "return_type": "int"
+    },
+    {
+        "name": "geteuid",
+        "nr": 172,
+        "nr_args": 0,
+        "args": [],
+        "return_type": "uid_t"
+    },
+    {
+        "name": "getegid",
+        "nr": 173,
+        "nr_args": 0,
+        "args": [],
+        "return_type": "gid_t"
     }
 ]

--- a/kernel/arch/x86_64/syscall_table.json
+++ b/kernel/arch/x86_64/syscall_table.json
@@ -2993,5 +2993,131 @@
         ],
         "return_type": "int",
         "abi": "c"
+    },
+    {
+        "name": "getresuid",
+        "nr": 166,
+        "nr_args": 3,
+        "args": [
+            [
+                "uid_t *",
+                "ruid"
+            ],
+            [
+                "uid_t *",
+                "euid"
+            ],
+            [
+                "uid_t *",
+                "suid"
+            ]
+        ],
+        "return_type": "int"
+    },
+    {
+        "name": "getresgid",
+        "nr": 167,
+        "nr_args": 3,
+        "args": [
+            [
+                "gid_t *",
+                "rgid"
+            ],
+            [
+                "gid_t *",
+                "egid"
+            ],
+            [
+                "gid_t *",
+                "sgid"
+            ]
+        ],
+        "return_type": "int"
+    },
+    {
+        "name": "setresuid",
+        "nr": 168,
+        "nr_args": 3,
+        "args": [
+            [
+                "uid_t",
+                "ruid"
+            ],
+            [
+                "uid_t",
+                "euid"
+            ],
+            [
+                "uid_t",
+                "suid"
+            ]
+        ],
+        "return_type": "int"
+    },
+    {
+        "name": "setresgid",
+        "nr": 169,
+        "nr_args": 3,
+        "args": [
+            [
+                "gid_t",
+                "rgid"
+            ],
+            [
+                "gid_t",
+                "egid"
+            ],
+            [
+                "gid_t",
+                "sgid"
+            ]
+        ],
+        "return_type": "int"
+    },
+    {
+        "name": "setreuid",
+        "nr": 170,
+        "nr_args": 2,
+        "args": [
+            [
+                "uid_t",
+                "ruid"
+            ],
+            [
+                "uid_t",
+                "euid"
+            ]
+        ],
+        "return_type": "int"
+    },
+    {
+        "name": "setregid",
+        "nr": 171,
+        "nr_args": 2,
+        "args": [
+            [
+                "gid_t",
+                "rgid"
+            ],
+            [
+                "gid_t",
+                "egid"
+            ]
+        ],
+        "return_type": "int"
+    },
+    {
+        "name": "geteuid",
+        "nr": 172,
+        "nr_args": 0,
+        "args": [],
+        "return_type": "uid_t"
+    },
+    {
+        "name": "getegid",
+        "nr": 173,
+        "nr_args": 0,
+        "args": [],
+        "return_type": "gid_t"
     }
 ]


### PR DESCRIPTION
Add various missing uid and gid related syscalls required by userspace, and change musl's creds code to match. It's also doing signal-based IPI'ing like it's supposed to now, so these syscalls should work in multithreaded processes.