### PR TITLE
x86_64/signal: initialize variable in inlined function

### DIFF
--- a/kernel/arch/x86_64/signal.c
+++ b/kernel/arch/x86_64/signal.c
@@ -169,7 +169,7 @@ static int fault_in_range(u8 *start, size_t len)
     unsigned long addr = (unsigned long) start;
     u8 *ptr;
     unsigned int dummy;
-    int err;
+    int err = 0;
 
     /* Page align our buffer */
     if (addr & (PAGE_SIZE - 1))


### PR DESCRIPTION
Otherwise build may fail on some toolchains.