### PR TITLE
Stable fixes and refactoring

### DIFF
--- a/kernel/include/onyx/filemap.h
+++ b/kernel/include/onyx/filemap.h
@@ -95,6 +95,7 @@ struct readpages_state
 struct page *readpages_next_page(struct readpages_state *state);
 
 void filemap_clear_dirty(struct page *page) REQUIRES(page);
+void filemap_unaccount_dirty(struct page *page, struct vm_object *obj);
 
 __END_CDECLS
 

--- a/kernel/include/onyx/hybrid_lock.h
+++ b/kernel/include/onyx/hybrid_lock.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 - 2022 Pedro Falcato
+ * Copyright (c) 2020 - 2025 Pedro Falcato
  * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  *
@@ -9,18 +9,14 @@
 #ifndef _ONYX_HYBRID_LOCK_H
 #define _ONYX_HYBRID_LOCK_H
 
-#include <onyx/conditional.h>
-#include <onyx/scoped_lock.h>
 #include <onyx/spinlock.h>
 #include <onyx/wait_queue.h>
-
-#include <onyx/atomic.hpp>
 
 __BEGIN_CDECLS
 
 struct socket;
-void sock_do_post_work(socket *sock);
-bool sock_needs_work(socket *sock);
+void sock_do_post_work(struct socket *sock);
+bool sock_needs_work(struct socket *sock);
 /**
  * @brief Works in a similar fashion to linux's socket_lock_t.
  * When used in a user context, the lock's user is supposed to lock it like a mutex, which may
@@ -30,9 +26,9 @@ bool sock_needs_work(socket *sock);
  */
 struct hybrid_lock
 {
-    spinlock lock_;
+    struct spinlock lock_;
     raw_spinlock_t owned;
-    wait_queue wq;
+    struct wait_queue wq;
 
 #ifdef __cplusplus
     void __wait_for_owned()
@@ -136,6 +132,9 @@ static inline bool hybrid_is_ours(const struct hybrid_lock *lock)
 __END_CDECLS
 
 #ifdef __cplusplus
+
+#include <onyx/scoped_lock.h>
+
 template <bool bh = false>
 class scoped_hybrid_lock
 {

--- a/kernel/include/onyx/inode.h
+++ b/kernel/include/onyx/inode.h
@@ -34,7 +34,7 @@ typedef unsigned int (*__ioctl)(int request, void *argp, struct file *file);
 typedef struct inode *(*__creat)(struct dentry *dentry, int mode, struct dentry *dir);
 typedef int (*__stat)(struct stat *buf, const struct path *path);
 typedef struct inode *(*__symlink)(struct dentry *dentry, const char *linkpath, struct dentry *dir);
-typedef unsigned int (*putdir_t)(struct dirent *, struct dirent *ubuf, unsigned int count);
+typedef int (*putdir_t)(struct dirent *, struct dirent *ubuf, unsigned int count);
 
 struct writepages_info
 {

--- a/kernel/include/onyx/iovec_iter.h
+++ b/kernel/include/onyx/iovec_iter.h
@@ -67,7 +67,7 @@ struct iovec_iter
 
     [[nodiscard]] bool empty()
     {
-        return nr_vecs == 0;
+        return bytes == 0;
     }
 
     [[nodiscard]] iovec curiovec() const
@@ -136,7 +136,7 @@ static inline size_t iovec_iter_bytes(struct iovec_iter *iter)
 
 static inline bool iovec_iter_empty(struct iovec_iter *iter)
 {
-    return iter->nr_vecs == 0;
+    return iter->bytes == 0;
 }
 
 __END_CDECLS

--- a/kernel/include/onyx/mm/kasan.h
+++ b/kernel/include/onyx/mm/kasan.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 - 2024 Pedro Falcato
+ * Copyright (c) 2019 - 2025 Pedro Falcato
  * This file is part of Onyx, and is released under the terms of the GPLv2 License
  * check LICENSE at the root directory for more information
  *
@@ -41,6 +41,15 @@ void kasan_flush_quarantine();
  * @param chunk_size Size of the chunk, in bytes
  */
 void kasan_quarantine_add_chunk(void *ptr, size_t chunk_size);
+
+struct page;
+
+/**
+ * @brief Add a single struct page to the quarantine
+ *
+ * @param page Page to add
+ */
+void kasan_quarantine_add_page(struct page *page);
 
 /**
  * @brief Get the redzone's size for the objsize

--- a/kernel/include/onyx/mount.h
+++ b/kernel/include/onyx/mount.h
@@ -15,9 +15,12 @@
 struct dentry;
 struct superblock;
 
-#define MNT_READONLY   (1U << 0)
-#define MNT_WRITE_HOLD (1U << 30)
-#define MNT_DOOMED     (1U << 31)
+#define MNT_READONLY    (1U << 0)
+#define MNT_STRICTATIME MS_STRICTATIME
+#define MNT_NOATIME     MS_NOATIME
+#define MNT_NODIRATIME  MS_NODIRATIME
+#define MNT_WRITE_HOLD  (1U << 30)
+#define MNT_DOOMED      (1U << 31)
 
 struct mount
 {

--- a/kernel/include/onyx/net/icmpv6.h
+++ b/kernel/include/onyx/net/icmpv6.h
@@ -90,7 +90,7 @@ public:
         sock_ops = &icmp6_ops;
     }
 
-    ~icmp6_socket() override = default;
+    ~icmp6_socket() = default;
 
     int bind(struct sockaddr *addr, socklen_t addrlen);
     int connect(struct sockaddr *addr, socklen_t addrlen, int flags);

--- a/kernel/include/onyx/net/inet_socket.h
+++ b/kernel/include/onyx/net/inet_socket.h
@@ -117,7 +117,7 @@ struct inet_socket : public socket
 
     void append_inet_rx_pbuf(packetbuf *buf);
 
-    virtual ~inet_socket();
+    ~inet_socket();
 
     int setsockopt_inet(int level, int opt, const void *optval, socklen_t len);
     int getsockopt_inet(int level, int opt, void *optval, socklen_t *len);

--- a/kernel/include/onyx/net/ipv6.h
+++ b/kernel/include/onyx/net/ipv6.h
@@ -15,6 +15,7 @@
 #include <uapi/netinet.h>
 #include <uapi/socket.h>
 
+#include <onyx/pair.hpp>
 #include <onyx/tuple.hpp>
 
 struct ip6hdr

--- a/kernel/include/onyx/net/socket.h
+++ b/kernel/include/onyx/net/socket.h
@@ -84,7 +84,7 @@ struct socket
      * to prevent race conditions.
      */
 
-    hybrid_lock socket_lock;
+    struct hybrid_lock socket_lock;
     bool bound;
     bool connected;
     bool reuse_addr : 1;
@@ -132,6 +132,7 @@ struct socket
         shutdown_state = 0;
         rcv_timeout = snd_timeout = 0;
         sock_ops = NULL;
+        hybrid_lock_init(&socket_lock);
         INIT_LIST_HEAD(&socket_backlog);
         pfi_init(&sock_pfi);
         sk_send_queued = 0;

--- a/kernel/include/onyx/packetbuf.h
+++ b/kernel/include/onyx/packetbuf.h
@@ -13,7 +13,9 @@
 
 #include <onyx/iovec_iter.h>
 #include <onyx/limits.h>
+#if __cplusplus
 #include <onyx/net/inet_route.h>
+#endif
 #include <onyx/page.h>
 #include <onyx/page_iov.h>
 
@@ -64,6 +66,9 @@ __END_CDECLS
  * implementation.
  *
  */
+
+#define PBF_COPY_ITER_PEEK (1 << 0)
+
 struct packetbuf
 {
     /* Reasoning behind this - We're going to need at
@@ -113,7 +118,9 @@ struct packetbuf
     };
 
     union {
+#ifdef __cplusplus
         inet_route route;
+#endif
         char proto_space[PACKETBUF_PROTO_SPACE];
     };
 
@@ -131,7 +138,7 @@ struct packetbuf
      */
     packetbuf()
         : refcount{1}, page_vec{}, phy_header{}, link_header{}, net_header{}, transport_header{},
-          data{}, tail{}, end{}, buffer_start{}, csum_offset{nullptr}, csum_start{nullptr},
+          data{}, tail{}, end{}, buffer_start{}, csum_offset{NULL}, csum_start{NULL},
           header_length{}, gso_size{}, gso_flags{}, needs_csum{0}, zero_copy{0}, domain{0}
     {
         route = {};
@@ -283,8 +290,6 @@ struct packetbuf
         __builtin_unreachable();
     }
 
-#define PBF_COPY_ITER_PEEK (1 << 0)
-
     /**
      * @brief Copy the packetbuf (or whatever is left of it) to iter
      *
@@ -321,7 +326,7 @@ struct packetbuf *packetbuf_clone(struct packetbuf *original);
 static inline bool pbf_can_try_put(struct packetbuf *pbf)
 {
     /* Using put with other page vecs is bound to break something */
-    return pbf->page_vec[1].page == nullptr;
+    return pbf->page_vec[1].page == NULL;
 }
 
 static inline unsigned int pbf_tail_room(struct packetbuf *pbf)
@@ -450,7 +455,7 @@ struct packetbuf *pbf_alloc(gfp_t gfp);
 struct packetbuf *pbf_alloc_sk(gfp_t gfp, struct socket *sock, unsigned int len);
 struct packetbuf *pbf_alloc_rx(gfp_t gfp, unsigned int len);
 ssize_t copy_to_pbf(struct packetbuf *pbf, struct iovec_iter *iter);
-
+ssize_t copy_from_pbf(struct packetbuf *pbf, struct iovec_iter *iter, unsigned int flags);
 __END_CDECLS
 
 #define PACKET_MAX_HEAD_LENGTH 128

--- a/kernel/include/onyx/vfs.h
+++ b/kernel/include/onyx/vfs.h
@@ -116,7 +116,7 @@ int fallocate_vfs(int mode, off_t offset, off_t len, struct file *file);
 
 int unlink_vfs(const char *path, int flags, int dirfd);
 
-char *readlink_vfs(struct dentry *dentry);
+char *readlink_vfs(const struct path *path);
 
 /* C does not support default args... */
 #ifdef __cplusplus
@@ -215,7 +215,7 @@ static inline bool inode_should_die(struct inode *ino)
 
 void inode_unlock_hashtable(struct superblock *sb, ino_t ino_nr);
 
-void inode_update_atime(struct inode *ino);
+void inode_update_atime(const struct path *path);
 void inode_update_ctime(struct inode *ino);
 void inode_update_mtime(struct inode *ino);
 

--- a/kernel/include/onyx/wait_queue.h
+++ b/kernel/include/onyx/wait_queue.h
@@ -225,9 +225,9 @@ bool signal_is_pending();
     __wait_for_event(wq, cond, THREAD_INTERRUPTIBLE, socket_lock.unlock_sock(this); sched_yield(); \
                      socket_lock.lock())
 
-#define wait_for_event_socklocked_interruptible_2(wq, cond, sock)                           \
-    __wait_for_event(wq, cond, THREAD_INTERRUPTIBLE, (sock)->socket_lock.unlock_sock(sock); \
-                     sched_yield(); (sock)->socket_lock.lock())
+#define wait_for_event_socklocked_interruptible_2(wq, cond, sock)                               \
+    __wait_for_event(wq, cond, THREAD_INTERRUPTIBLE, __unlock_sock(&(sock)->socket_lock, sock); \
+                     sched_yield(); hybrid_lock(&(sock)->socket_lock);)
 
 #define wait_for_event_writelocked_interruptible(wq, cond, lock)                        \
     __wait_for_event(wq, cond, THREAD_INTERRUPTIBLE, write_unlock(lock); sched_yield(); \

--- a/kernel/kernel/fs/file.cpp
+++ b/kernel/kernel/fs/file.cpp
@@ -1157,7 +1157,7 @@ ssize_t sys_pwritev(int fd, const struct iovec *vec, int veccnt, off_t offset)
     return write_iter_vfs(f.get_file(), offset, &iter, 0);
 }
 
-unsigned int putdir(struct dirent *buf, struct dirent *ubuf, unsigned int count);
+int putdir(struct dirent *buf, struct dirent *ubuf, unsigned int count);
 
 int sys_getdents(int fd, struct dirent *dirp, unsigned int count)
 {
@@ -1174,9 +1174,7 @@ int sys_getdents(int fd, struct dirent *dirp, unsigned int count)
     struct getdents_ret ret_buf = {};
     ret = getdents_vfs(count, putdir, dirp, fil->f_seek, &ret_buf, fil);
     if (ret < 0)
-    {
-        return -errno;
-    }
+        return ret;
 
     inode_update_atime(&fil->f_path);
     fil->f_seek = ret_buf.new_off;

--- a/kernel/kernel/fs/file.cpp
+++ b/kernel/kernel/fs/file.cpp
@@ -1808,7 +1808,7 @@ ssize_t sys_readlinkat(int dirfd, const char *upathname, char *ubuf, size_t bufs
     if (st)
         goto out;
 
-    buf = readlink_vfs(path.dentry);
+    buf = readlink_vfs(&path);
     if (IS_ERR_OR_NULL(buf))
     {
         if (!buf)

--- a/kernel/kernel/fs/file.cpp
+++ b/kernel/kernel/fs/file.cpp
@@ -1178,6 +1178,7 @@ int sys_getdents(int fd, struct dirent *dirp, unsigned int count)
         return -errno;
     }
 
+    inode_update_atime(&fil->f_path);
     fil->f_seek = ret_buf.new_off;
 
     ret = ret_buf.read;

--- a/kernel/kernel/fs/mount.c
+++ b/kernel/kernel/fs/mount.c
@@ -666,7 +666,7 @@ static int mounts_open(struct file *filp)
     return seq_open(filp, &mounts_seq_ops);
 }
 
-static const struct proc_file_ops mounts_proc_ops = {
+const struct proc_file_ops mounts_proc_ops = {
     .open = mounts_open,
     .release = seq_release,
     .read_iter = seq_read_iter,

--- a/kernel/kernel/fs/mount.c
+++ b/kernel/kernel/fs/mount.c
@@ -434,14 +434,16 @@ out:
     return err ? ERR_PTR(err) : mnt;
 }
 
-#define VALID_MOUNT_FLAGS (MS_RDONLY | MS_SILENT | MS_RELATIME | MS_REMOUNT)
+#define VALID_MOUNT_FLAGS \
+    (MS_RDONLY | MS_SILENT | MS_RELATIME | MS_REMOUNT | MS_BIND | MS_STRICTATIME | MS_NOATIME)
+
+/* These flags have the same bits internally as in the argument */
+#define SAME_FLAGS_MASK (MNT_STRICTATIME | MNT_NOATIME | MNT_NODIRATIME | MNT_READONLY)
 
 static unsigned long translate_mount_flags(unsigned long flags)
 {
-    unsigned long mflags = 0;
+    unsigned long mflags = flags & SAME_FLAGS_MASK;
 
-    if (flags & MS_RDONLY)
-        mflags |= MNT_READONLY;
     return mflags;
 }
 

--- a/kernel/kernel/fs/namei.cpp
+++ b/kernel/kernel/fs/namei.cpp
@@ -170,6 +170,7 @@ std::string_view get_token_from_path(lookup_path &path, bool no_consume_if_last)
 static int dentry_follow_symlink(nameidata &data, dentry *symlink, unsigned int flags = 0)
 {
     struct inode *ino = symlink->d_inode;
+    struct path p = {symlink, data.cur.mount};
 
     if (!inode_can_access(ino, FILE_ACCESS_EXECUTE))
         return -EACCES;
@@ -181,7 +182,7 @@ static int dentry_follow_symlink(nameidata &data, dentry *symlink, unsigned int 
     if (++data.nloops == nameidata::max_loops)
         return -ELOOP;
 
-    auto target_str = readlink_vfs(symlink);
+    auto target_str = readlink_vfs(&p);
     if (IS_ERR_OR_NULL(target_str))
         return !target_str ? -errno : PTR_ERR(target_str);
 

--- a/kernel/kernel/fs/proc/pid.c
+++ b/kernel/kernel/fs/proc/pid.c
@@ -526,6 +526,7 @@ static const struct file_ops proc_fd_fops = {
 };
 
 extern const struct proc_file_ops proc_maps_ops;
+extern const struct proc_file_ops mounts_proc_ops;
 
 #define ARRAY_SIZE(arr) (sizeof(arr) / sizeof((arr)[0]))
 
@@ -536,6 +537,7 @@ static const struct pid_attr pid_attrs[] = {
     {"statm", S_IFREG | 0444, &proc_statm_ops},
     {"fd", S_IFDIR | 0444, &proc_noop, &proc_fd_operations, &proc_fd_fops},
     {"maps",  S_IFREG | 0400, &proc_maps_ops},
+    {"mounts", S_IFREG | 0400, &mounts_proc_ops},
 };
 
 // clang-format on

--- a/kernel/kernel/fs/vfs.cpp
+++ b/kernel/kernel/fs/vfs.cpp
@@ -794,6 +794,8 @@ void put_dentry_to_dirent(struct dirent *buf, dentry *dentry, const char *specia
 bool apply_sugid_permissions(file *f)
 {
     auto ino = f->f_ino;
+    bool changed = false;
+
     if (!(ino->i_mode & (S_ISGID | S_ISUID)))
         return false;
 
@@ -801,13 +803,15 @@ bool apply_sugid_permissions(file *f)
 
     if (ino->i_mode & S_ISUID)
     {
+        changed |= g.get()->euid != ino->i_uid;
         g.get()->euid = ino->i_uid;
     }
 
     if (ino->i_mode & S_ISGID)
     {
+        changed |= g.get()->egid != ino->i_gid;
         g.get()->egid = ino->i_gid;
     }
 
-    return true;
+    return changed;
 }

--- a/kernel/kernel/mm/vm.c
+++ b/kernel/kernel/mm/vm.c
@@ -778,7 +778,7 @@ static struct vm_area_struct *vma_create(struct vma_iterator *vmi, unsigned int 
                 goto unmap_vma;
             }
 
-            inode_update_atime(ino);
+            inode_update_atime(&file->f_path);
             goto out;
         }
     }

--- a/kernel/kernel/net/packetbuf.cpp
+++ b/kernel/kernel/net/packetbuf.cpp
@@ -404,6 +404,11 @@ out:
     return copied;
 }
 
+ssize_t copy_from_pbf(struct packetbuf *pbf, struct iovec_iter *iter, unsigned int flags)
+{
+    return pbf->copy_iter(*iter, flags);
+}
+
 void pbf_free(struct packetbuf *pbf)
 {
     pbf->~packetbuf();

--- a/kernel/kernel/net/socket.cpp
+++ b/kernel/kernel/net/socket.cpp
@@ -769,7 +769,6 @@ static void socket_sanity_check(socket *sock)
     DCHECK(sock_ops->getsockopt);
     DCHECK(sock_ops->setsockopt);
     DCHECK(sock_ops->close);
-    DCHECK(sock_ops->handle_backlog);
     DCHECK(sock_ops->poll);
 }
 

--- a/kernel/kernel/net/socket.cpp
+++ b/kernel/kernel/net/socket.cpp
@@ -1129,6 +1129,16 @@ int socket::setsockopt_socket_level(int optname, const void *optval, socklen_t o
     return -ENOPROTOOPT;
 }
 
+int getsockopt_socket_level(struct socket *sock, int optname, void *optval, socklen_t *optlen)
+{
+    return sock->getsockopt_socket_level(optname, optval, optlen);
+}
+
+int setsockopt_socket_level(struct socket *sock, int optname, const void *optval, socklen_t optlen)
+{
+    return sock->setsockopt_socket_level(optname, optval, optlen);
+}
+
 int sys_getsockopt(int sockfd, int level, int optname, void *optval, socklen_t *optlen)
 {
     auto f = get_socket_fd(sockfd);
@@ -1578,4 +1588,9 @@ int sock_stream_error(struct socket *sock, int err, int flags)
     if (err == -EPIPE && !(flags & MSG_NOSIGNAL))
         kernel_raise_signal(SIGPIPE, get_current_process(), 0, NULL);
     return err;
+}
+
+void socket_init(struct socket *socket)
+{
+    new (socket) struct socket;
 }

--- a/kernel/kernel/net/unix.cpp
+++ b/kernel/kernel/net/unix.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 - 2024 Pedro Falcato
+ * Copyright (c) 2022 - 2025 Pedro Falcato
  * This file is part of Onyx, and is released under the terms of the MIT License
  * check LICENSE at the root directory for more information
  *
@@ -20,6 +20,7 @@
 #include <onyx/poll.h>
 #include <onyx/process.h>
 
+#include <onyx/pair.hpp>
 #include <onyx/utility.hpp>
 
 #ifdef CONFIG_KUNIT
@@ -357,7 +358,7 @@ public:
         peer_nowr = false;
     }
 
-    ~un_socket() override;
+    ~un_socket();
 
     int bind(sockaddr *addr, socklen_t addrlen);
 

--- a/kernel/lib/libk/include/sys/mount.h
+++ b/kernel/lib/libk/include/sys/mount.h
@@ -5,7 +5,7 @@
 extern "C" {
 #endif
 
-#include <sys/ioctl.h>
+#include <uapi/ioctl.h>
 
 #define BLKROSET   _IO(0x12, 93)
 #define BLKROGET   _IO(0x12, 94)


### PR DESCRIPTION
- refactoring in the net area
- added /proc/pid/mounts
- fix NR_DIRTY underflows with tmpfs files
- fix 0 size writes to ext2 by improving iovec_iter
- relatime support (including NOATIME, STRICTATIME, NODIRATIME)
- fix the case where getdents never updated atime
- fix the case where AT_SECURE was set without us actually changing privileges
- KASAN page quarantining support